### PR TITLE
Fix Claude resume cwd for project paths with spaces

### DIFF
--- a/internal/session/claude.go
+++ b/internal/session/claude.go
@@ -115,6 +115,9 @@ func parseClaude(path string) (Row, bool) {
 		}
 		if record.CWD != "" {
 			cwd = record.CWD
+			if launchCWD == "" {
+				launchCWD = existingDir(record.CWD)
+			}
 			if claudeProjectDir(record.CWD) == projectDir {
 				launchCWD = record.CWD
 			}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -173,6 +173,37 @@ func TestClaudeResumeUsesProjectBucketCWD(t *testing.T) {
 	}
 }
 
+func TestClaudeResumeUsesObservedCWDWhenProjectSlugIsLossy(t *testing.T) {
+	root := t.TempDir()
+	claudeHome := filepath.Join(root, "claude")
+	project := filepath.Join(root, "fable is arama")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CODEX_HOME", filepath.Join(root, "empty-codex"))
+	t.Setenv("CLAUDE_HOME", claudeHome)
+	t.Setenv("JCODE_HOME", filepath.Join(root, "empty-jcode"))
+	t.Setenv("OPENCODE_DATA_HOME", filepath.Join(root, "empty-opencode"))
+	t.Setenv("GEMINI_CLI_HOME", filepath.Join(root, "empty-gemini"))
+
+	sessionID := "cccccccc-1111-2222-3333-dddddddddddd"
+	projectDir := strings.ReplaceAll(claudeProjectDir(project), " ", "-")
+	writeFile(t, filepath.Join(claudeHome, "projects", projectDir, sessionID+".jsonl"), `
+{"type":"user","message":{"role":"user","content":"started in project"},"timestamp":"2026-06-02T10:00:00Z","cwd":"`+project+`","sessionId":"`+sessionID+`"}
+`)
+
+	rows := Discover()
+	if len(rows) != 1 {
+		t.Fatalf("expected one row, got %d", len(rows))
+	}
+	if rows[0].CWD != project {
+		t.Fatalf("display cwd = %q, want latest cwd %q", rows[0].CWD, project)
+	}
+	if rows[0].resumeCWD() != project {
+		t.Fatalf("resume cwd = %q, want observed cwd %q", rows[0].resumeCWD(), project)
+	}
+}
+
 func TestCodexUsesLatestTurnContextCWD(t *testing.T) {
 	root := t.TempDir()
 	codexHome := filepath.Join(root, "codex")


### PR DESCRIPTION
## Summary
- prefer the first observed real Claude cwd before falling back to the lossy project-dir slug reconstruction
- keep project-bucket cwd behavior for sessions that continue in nested folders
- add a regression test for Claude project slugs that collapse spaces into hyphens

## Tests
- docker run --rm -v "/home/aytzey/Documents/showagent":/src -w /src golang:1.25.9 sh -lc 'export PATH=/usr/local/go/bin:/home/aytzey/.nvm/versions/node/v24.11.0/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex-path:/home/aytzey/.codex/tmp/arg0/codex-arg0K2GQG2:/home/aytzey/.bun/bin:/home/aytzey/.deno/bin:/home/aytzey/.nvm/versions/node/v24.11.0/bin:/home/aytzey/.cargo/bin:/home/aytzey/.local/bin:/home/aytzey/.local/kitty.app/bin:/home/aytzey/.bun/bin:/home/aytzey/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin; go test ./internal/session -run "TestClaudeResumeUsesProjectBucketCWD|TestClaudeResumeUsesObservedCWDWhenProjectSlugIsLossy" && go test ./...'
- docker run --rm -v "/home/aytzey/Documents/showagent":/src -w /src golang:1.25.9 sh -lc 'export PATH=/usr/local/go/bin:/home/aytzey/.nvm/versions/node/v24.11.0/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex-path:/home/aytzey/.codex/tmp/arg0/codex-arg0K2GQG2:/home/aytzey/.bun/bin:/home/aytzey/.deno/bin:/home/aytzey/.nvm/versions/node/v24.11.0/bin:/home/aytzey/.cargo/bin:/home/aytzey/.local/bin:/home/aytzey/.local/kitty.app/bin:/home/aytzey/.bun/bin:/home/aytzey/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin; go test -race ./...'

Verified locally with the real Claude session c4c6e5a8-2a14-4b35-b122-797ac56177a6: showagent info now resolves cwd to /home/aytzey/Documents/fable is arama.