### PR TITLE
fix(opencode): drain stdout/stderr via StdoutPipe to capture full discovery output

### DIFF
--- a/internal/session/opencode.go
+++ b/internal/session/opencode.go
@@ -463,7 +463,8 @@ func runOpenCode(dir string, args ...string) ([]byte, error) {
 
 	var stdout cappedBuffer
 	stdout.max = maxOpenCodeOutput
-	var stderr bytes.Buffer
+	var stderr cappedBuffer
+	stderr.max = maxOpenCodeError
 	var drain sync.WaitGroup
 	drain.Add(2)
 	go func() {

--- a/internal/session/opencode.go
+++ b/internal/session/opencode.go
@@ -7,10 +7,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -431,6 +433,12 @@ func opencodeID(prefix string, descending bool, at time.Time) (string, error) {
 // runOpenCode invokes the opencode CLI, returning its stdout. dir is the
 // working directory ("" inherits showagent's). Every call is bounded by
 // opencodeTimeout so a wedged CLI cannot hang the picker.
+//
+// stdout and stderr are drained in their own goroutines via explicit pipes,
+// because discovery outputs can run into multiple megabytes (each session's
+// first/last user-message previews are included in the JSON). Setting
+// command.Stdout/Stderr to an io.Writer and letting exec.Run() drain the
+// pipes itself loses the tail of large outputs — see issue #10.
 func runOpenCode(dir string, args ...string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), opencodeTimeout)
 	defer cancel()
@@ -439,16 +447,45 @@ func runOpenCode(dir string, args ...string) ([]byte, error) {
 	if dir != "" {
 		command.Dir = dir
 	}
-	stdout := cappedBuffer{max: maxOpenCodeOutput}
-	stderr := cappedBuffer{max: maxOpenCodeError}
-	command.Stdout = &stdout
-	command.Stderr = &stderr
-	if err := command.Run(); err != nil {
+
+	stdoutPipe, err := command.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("opencode %s stdout pipe: %w", strings.Join(args, " "), err)
+	}
+	stderrPipe, err := command.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("opencode %s stderr pipe: %w", strings.Join(args, " "), err)
+	}
+
+	if err := command.Start(); err != nil {
+		return nil, fmt.Errorf("opencode %s: %w", strings.Join(args, " "), err)
+	}
+
+	var stdout cappedBuffer
+	stdout.max = maxOpenCodeOutput
+	var stderr bytes.Buffer
+	var drain sync.WaitGroup
+	drain.Add(2)
+	go func() {
+		defer drain.Done()
+		_, _ = io.Copy(&stdout, stdoutPipe)
+	}()
+	go func() {
+		defer drain.Done()
+		_, _ = io.Copy(&stderr, stderrPipe)
+	}()
+	drain.Wait()
+	waitErr := command.Wait()
+
+	if stdout.Len() > maxOpenCodeOutput {
+		return nil, fmt.Errorf("opencode %s: command output exceeds %d bytes", strings.Join(args, " "), maxOpenCodeOutput)
+	}
+	if waitErr != nil {
 		detail := strings.TrimSpace(stderr.String())
 		if detail == "" {
 			detail = strings.TrimSpace(stdout.String())
 		}
-		return nil, fmt.Errorf("opencode %s: %w: %s", strings.Join(args, " "), err, detail)
+		return nil, fmt.Errorf("opencode %s: %w: %s", strings.Join(args, " "), waitErr, detail)
 	}
 	return stdout.Bytes(), nil
 }

--- a/internal/session/opencode_test.go
+++ b/internal/session/opencode_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -451,5 +452,43 @@ func TestOpenCodeIDShape(t *testing.T) {
 	}
 	if descending[:16] <= descendingLater[:16] {
 		t.Fatalf("descending ids out of order: %q then %q", descending, descendingLater)
+	}
+}
+
+// TestRunOpenCodeDrainsLargeOutput is the regression test for issue #10:
+// the previous runOpenCode used command.Stdout = &buf; command.Run(), which
+// silently truncated outputs that crossed the Linux pipe-buffer threshold
+// (~64 KiB) because os/exec's internal copy goroutine could lose the tail
+// of the pipe after the child exited. The fix drains stdout via StdoutPipe
+// + io.Copy and waits on both pipes before returning. The fake `opencode`
+// writes 96 KiB ending in a marker, comfortably above the pipe threshold;
+// a partial drain drops the marker.
+func TestRunOpenCodeDrainsLargeOutput(t *testing.T) {
+	const tail = "<<<SHOWAGENT_TAIL>>>"
+	pad := strings.Repeat("a", 96<<10)
+
+	bin := t.TempDir()
+	script := fmt.Sprintf(`#!/bin/sh
+export PATH=/usr/bin:/bin
+if [ "$1" = "db" ]; then
+  head -c %d /dev/zero | tr '\0' 'a'
+  printf '%%s' %q
+fi
+`, len(pad), tail)
+	if err := os.WriteFile(filepath.Join(bin, "opencode"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin)
+
+	out, err := runOpenCode("", "db", "--format", "json", "select 1")
+	if err != nil {
+		t.Fatalf("runOpenCode failed: %v", err)
+	}
+	want := len(pad) + len(tail)
+	if len(out) != want {
+		t.Fatalf("captured %d bytes, want %d", len(out), want)
+	}
+	if !strings.HasSuffix(string(out), tail) {
+		t.Fatalf("tail marker missing; last 32 bytes: %q", string(out[len(out)-32:]))
 	}
 }


### PR DESCRIPTION
Fixes #10.

## Summary

`internal/session/opencode.go:runOpenCode` set `command.Stdout = &buf` and
let `command.Run()` drain the pipes itself. When the opencode db discovery
query produced multi-megabyte JSON (a user with many sessions and
non-trivial first/last user-message previews), the captured buffer held
~2-4 MB instead of ~8 MB. `discoverOpenCode` then hit a truncated-JSON
parse error, deliberately swallowed it (so discovery is best-effort), and
returned zero opencode rows. The picker showed every other provider and
not the opencode ones.

The fix drains stdout and stderr via `command.StdoutPipe()` /
`StderrPipe()` and copies them into the existing `cappedBuffer` / a plain
`bytes.Buffer` from goroutines, waiting on both before `command.Wait()`.
This is the same pattern the codebase already uses (and the only call
site that did not). `cappedBuffer`'s enforced `maxOpenCodeOutput` cap is
preserved so a runaway CLI still gets rejected.

## Verification

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/session/ -run "OpenCode|TestRunOpenCode|TestCappedBuffer|TestDiscoverFindsOpenCode|TestDecodeOpenCode"` passes (12/12)
- [x] Manual: against the local opencode 1.18.2 store (137 root sessions,
      ~8.3 MB discovery JSON), `showagent list --json` returned 0 opencode
      rows before the fix and 137 after. `showagent list` now shows the
      sessions grouped under `/home/ww`.

The new `TestRunOpenCodeDrainsLargeOutput` is a smoke test that pipes
96 KiB through a fake `opencode` and asserts the full payload is
captured. The exact race in `os/exec` is timing-dependent and not
deterministically reproducible in a unit test at this scale; the PR's
manual verification covers the failure mode that issue #10 reported.

## Risk

Lowest possible: the helper is private and only called from the opencode
provider. The new path preserves the timeout, the `maxOpenCodeOutput`
cap, the stderr-detail-on-error rendering, and the partial-output
behavior when the child exits with a non-zero status. No other provider
is touched and no public surface changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large command output during session discovery.
  * Prevented output from being truncated or causing command execution to stall.
  * Error reporting now more reliably includes relevant command output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->