### PR TITLE
fix(claude): restore converted sessions without model warning

### DIFF
--- a/internal/session/handoff.go
+++ b/internal/session/handoff.go
@@ -288,7 +288,7 @@ func writeClaudeConverted(source Row, turns []Turn) (Row, error) {
 					"id":            syntheticClaudeAPIID("msg", messageID),
 					"type":          "message",
 					"role":          "assistant",
-					"model":         "converted-transcript",
+					"model":         "<synthetic>",
 					"content":       []map[string]string{{"type": "text", "text": turn.Text}},
 					"stop_reason":   "end_turn",
 					"stop_sequence": nil,

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -531,6 +531,9 @@ func TestConvertCodexToClaudeCreatesSessionFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if !strings.Contains(string(content), `"model":"<synthetic>"`) {
+		t.Fatalf("converted claude assistant model is not synthetic:\n%s", content)
+	}
 	if !strings.Contains(string(content), `"id":"msg_`) {
 		t.Fatalf("converted claude assistant message id is not API-shaped:\n%s", content)
 	}


### PR DESCRIPTION
## Summary

Converted Codex sessions now use Claude Code's native `<synthetic>` model marker. Resume no longer tries to restore the invalid `converted-transcript` model and emit the reported warning.

Local session evidence covered Claude Code 2.1.220 and 2.1.235. Claude 2.1.220 compacted existing converted sessions despite the warning, so this PR fixes the confirmed restore-marker defect without claiming a separate transcript-loss reproduction.

Fixes #15

## Verification

- [x] `go test ./... -race -shuffle=on`
- [x] `go vet ./...`
- [x] `golangci-lint run` with v2.12.2
- [x] `govulncheck` v1.6.0: no vulnerabilities found
- [x] Documentation reviewed; no CLI flag or trust-boundary documentation changed

## Provider safety

- [x] Existing sessions are not modified unexpectedly
- [x] Tests use temporary provider homes, not real local session stores
- [x] Format claims identify the upstream CLI versions used for verification


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the model label shown for synthetic assistant messages in converted Claude session transcripts.

* **Tests**
  * Added coverage to verify that converted assistant records use the updated synthetic model label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->