### PR TITLE
docs: record verified 0.11.3 distribution and compatibility

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -33,7 +33,7 @@ jobs:
           TAG: ${{ inputs.tag }}
         run: |
           set -eu
-          printf '%s' "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'
+          printf '%s' "$TAG" | grep -Eq '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
           gh release view "$TAG" --json tagName,isDraft,isPrerelease |
             jq -e --arg tag "$TAG" '.tagName == $tag and .isDraft == false and .isPrerelease == false'
           gh release download "$TAG" --dir dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           TAG: ${{ github.ref_name }}
         run: |
           set -eu
-          printf '%s' "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'
+          printf '%s' "$TAG" | grep -Eq '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
           git fetch --no-tags origin main
           git merge-base --is-ancestor "$GITHUB_SHA" origin/main
       - uses: actions/setup-go@v7.0.0

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -17,6 +17,26 @@ test. This page distinguishes the checks we can report.
 
 ## Recorded checks
 
+### Published v0.11.3, 2026-09-07
+
+The [release workflow](https://github.com/aytzey/showagent/actions/runs/34168549236)
+passed Linux race/shuffled tests, built all five targets, and passed the Linux
+amd64 binary's isolated handoff smoke. All 17 published files were downloaded
+after publication and passed inventory, checksum, and archive/MCPB byte checks.
+
+The published Windows amd64 executable's GitHub build attestation was verified.
+That exact `showagent v0.11.3` binary passed all six isolated fixture checks on
+Windows 11, and the actual Codex **0.153.4** reader returned three visible turns
+from the converted Claude-format fixture. Its SHA256 is
+`809d550a497da22712c63abd4229d9dd67bb85fa4a4e907613c6002a567777d5`.
+No model call, real Claude CLI resume, or MCP desktop-host installation was
+performed. These checks preserve the distinctions in the table above.
+
+[Homebrew CI](https://github.com/aytzey/homebrew-tap/actions/runs/34168872534)
+also installed the published formula on Linux and macOS, passed its test, and
+reported `showagent v0.11.3` from both hosts. This is native CLI installation
+evidence, not an agent-resume check.
+
 ### Local growth-readiness build, 2026-09-07
 
 These checks used the unreleased Windows amd64 build
@@ -84,7 +104,7 @@ that a real model loaded or continued an imported conversation. See the
 
 ## Recording a native check
 
-The reusable smoke harness creates its own temporary stores and strips inherited
+The reusable smoke harness requires Python 3.10+, creates its own temporary stores and strips inherited
 credentials, executable paths, and provider overrides. It never calls a model:
 
 ```sh

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -7,14 +7,14 @@ has not been released yet.
 
 ## Channel snapshot
 
-Checked on 2026-09-06; these are observations, not pinned upgrade targets.
+Checked on 2026-09-07; these are observations, not pinned upgrade targets.
 
 | Channel | Observed version | What to verify |
 |---|---|---|
-| GitHub latest / shell installer | v0.11.2 | The platform archive, its SHA256SUMS entry, and the commands in that release's README |
+| GitHub latest / shell installer | v0.11.3 | All 17 published files downloaded and verified; [release workflow](https://github.com/aytzey/showagent/actions/runs/34168549236) passed |
 | `go install ...@latest` | Resolved Go module tag | `showagent --version` and `showagent --help`; this installs a tagged module, not the current `main` checkout |
-| [Homebrew tap](https://github.com/aytzey/homebrew-tap/blob/main/Formula/showagent.rb) | 0.11.1 | Formula URL/hash and installed binary; the tap is a separate repository |
-| Published MCPB files and repository `server.json` | 0.11.0 | The MCP tools returned by that bundle, its native binary, and client compatibility |
+| [Homebrew tap](https://github.com/aytzey/homebrew-tap/blob/main/Formula/showagent.rb) | 0.11.3 | [Linux and macOS install/test checks](https://github.com/aytzey/homebrew-tap/actions/runs/34168872534) passed against the published archives |
+| Published MCPB files, MCP Registry and repository `server.json` | 0.11.3 | Five bundles use the same binaries as CLI downloads; [registry publication](https://github.com/aytzey/showagent/actions/runs/34168794428) passed and the live API reports this version as active/latest |
 
 The v0.11.0 CLI does not have the newer `transcript` CLI command. Its MCP server
 already exposes `get_transcript`; missing a CLI subcommand does **not** mean the
@@ -27,7 +27,7 @@ unrelated packages to have identical version numbers.
 
 The tag workflow builds Linux and macOS `amd64`/`arm64` and experimental Windows
 `amd64`. Each target has an archive, a standalone binary, and a `.mcpb` bundle.
-Python 3 is a release/test dependency only; the installed Go binary needs no
+Python 3.10+ is a release/test dependency only; the installed Go binary needs no
 Python runtime. The MCPB ZIP contains the same binary bytes as the CLI archive,
 a manifest, the license, and the README from the tagged source.
 

--- a/server.json
+++ b/server.json
@@ -8,49 +8,49 @@
     "source": "github"
   },
   "websiteUrl": "https://github.com/aytzey/showagent#install",
-  "version": "0.11.0",
+  "version": "0.11.3",
   "packages": [
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/aytzey/showagent/releases/download/v0.11.0/showagent_v0.11.0_linux_amd64.mcpb",
-      "version": "0.11.0",
-      "fileSha256": "13f02ab865b08ac3f9460dcca909a212e5e8ccae8314d1100987253cf088ed62",
+      "identifier": "https://github.com/aytzey/showagent/releases/download/v0.11.3/showagent_v0.11.3_linux_amd64.mcpb",
+      "version": "0.11.3",
+      "fileSha256": "976df1cbe58d7ba432681b7ea42a9f52037e2bc22f0ae52c5459b025a310a51e",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/aytzey/showagent/releases/download/v0.11.0/showagent_v0.11.0_linux_arm64.mcpb",
-      "version": "0.11.0",
-      "fileSha256": "0d39c29fb7008b82b2ed2d4c78f51364251a5748c67cc911e0e0965dd556f153",
+      "identifier": "https://github.com/aytzey/showagent/releases/download/v0.11.3/showagent_v0.11.3_linux_arm64.mcpb",
+      "version": "0.11.3",
+      "fileSha256": "380fe9bc12970ea17a0e293c8d361a52151d5b823ad019613dfc66f70c3967f7",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/aytzey/showagent/releases/download/v0.11.0/showagent_v0.11.0_darwin_amd64.mcpb",
-      "version": "0.11.0",
-      "fileSha256": "1260859664d26b3038610f6011eadcf3d390de3eb55273dffa901c6fae602bcb",
+      "identifier": "https://github.com/aytzey/showagent/releases/download/v0.11.3/showagent_v0.11.3_darwin_amd64.mcpb",
+      "version": "0.11.3",
+      "fileSha256": "1bfd485dc12255330a36b03ccdd3144597a2870007ba6b6d2b22b273b69ac67f",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/aytzey/showagent/releases/download/v0.11.0/showagent_v0.11.0_darwin_arm64.mcpb",
-      "version": "0.11.0",
-      "fileSha256": "e21bc7d34c221faf85b53c721b922c74e099cd8a4420e18581a166c626bc552f",
+      "identifier": "https://github.com/aytzey/showagent/releases/download/v0.11.3/showagent_v0.11.3_darwin_arm64.mcpb",
+      "version": "0.11.3",
+      "fileSha256": "226322cb1a0d1054f4814ce55aaab115287cfd8245375c4e2a2d598c92c22eaa",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/aytzey/showagent/releases/download/v0.11.0/showagent_v0.11.0_windows_amd64.mcpb",
-      "version": "0.11.0",
-      "fileSha256": "19e3096c650c5118d234e1f4485799c89417ef0d40052817b6cda6573d698546",
+      "identifier": "https://github.com/aytzey/showagent/releases/download/v0.11.3/showagent_v0.11.3_windows_amd64.mcpb",
+      "version": "0.11.3",
+      "fileSha256": "96545d16652e95b36c0563de7b1712dc4d30a3e3de77731224e1cabd9fea5c41",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

GitHub, Homebrew, and the MCP Registry now publish showagent 0.11.3. The repository manifest now matches the verified public release asset, and the documentation records the actual release checks: five packaged targets, isolated Linux/Windows conversion, Codex 0.153.4 visible-history loading, and successful Homebrew installation on Linux/macOS.

The local test instructions now specify Python 3.10+, required by the handoff harness. Release and registry tag gates also reject leading-zero versions immediately, matching the existing artifact validator. These follow-ups do not change the released Go binary.

Related: #22

## Verification

- The committed manifest's SHA256 exactly matches the downloaded release `server.json`; all 17 release assets passed content and checksum verification.
- [Release CI](https://github.com/aytzey/showagent/actions/runs/34168549236), [MCP publication](https://github.com/aytzey/showagent/actions/runs/34168794428), and [Linux/macOS Homebrew checks](https://github.com/aytzey/homebrew-tap/actions/runs/34168872534) passed.
- Workflow lint and diff checks passed locally. This PR's CI checks the final source.
- Native Codex reader evidence remains separate from authenticated model continuation; no model call or real user session was used.

## Provider safety

Published URLs and hashes refer only to the already available 0.11.3 assets. No provider adapter or session storage behavior changes in this PR.
