### PR TITLE
feat: import ChatGPT and Claude conversations

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ supported stores and brings their sessions into one terminal picker:
 - **Switch agents** — preview what will carry over, then write a new session
   for the target agent. File-backed copies are private and written atomically;
   OpenCode imports go through its own CLI. Originals are preserved.
+- **Bring web chats into your coding workflow** — import a public ChatGPT or
+  Claude share link, a transcript file, or pasted text into a native local
+  session. You can also add imported text to the context of an exact Codex
+  session without starting a model turn.
 - **Keep your history local** — no hosted service, telemetry, or showagent
   account. The optional updater uses the network; an MCP client may send
   requested transcript content to its model provider. See the [privacy FAQ](#faq).
@@ -153,6 +157,10 @@ showagent transcript latest --max-turns 50 --json
 showagent resume latest    # reopen the most recent session, any agent
 showagent convert SOURCE_SESSION_ID --to claude --dry-run
                            # preview exactly what a hand-off would carry/drop
+showagent import --url CHAT_SHARE_URL --to codex --cwd ./my-project
+                           # create a native coding-agent session from a public web chat
+showagent import --file conversation.txt --into codex:EXACT_SESSION_ID
+                           # add text to an existing Codex session's context
 showagent info latest      # exact resume command + storage location
 showagent mcp              # serve session history to MCP-capable agents (stdio)
 showagent mcp --read-only  # same search/transcript tools, without tools that write copies
@@ -165,6 +173,9 @@ showagent --help           # full CLI help
 Replace `SOURCE_SESSION_ID` with the ID you selected from `showagent list`.
 The `transcript` command is not present in older builds such as v0.11.0;
 check [distribution details](docs/distribution.md) if your help output differs.
+See [web conversation import](docs/web-import.md) for accepted transcript
+formats, security boundaries, and the difference between creating a session
+and adding context to an existing one.
 
 ### Keybindings
 
@@ -182,6 +193,7 @@ check [distribution details](docs/distribution.md) if your help output differs.
 | `n` | Branch: copy the transferable conversation to a new session in the same agent |
 | `y` | Toggle the provider's yolo resume mode (jcode/Pi add no flag) |
 | `C` | Compound: resume with a learnings-capture prompt (see below) |
+| `i` | Import a ChatGPT/Claude share link or pasted transcript |
 | `d`, `del`, `backspace` | Delete the session — second press confirms, moving disarms |
 | `r` | Rescan session stores (keeps cursor, search, and filters) |
 | `?` | Toggle the full keybinding overlay |
@@ -218,6 +230,13 @@ before writing anything: source session, target provider, workspace, scope,
 transferable turn count, last user ask, and the agent-specific state that will
 be dropped. Remove `--dry-run` to write the converted session, then showagent
 prints the resume recipe for the new row.
+
+`showagent import --url <public-share-url> --to <provider> --cwd <directory>`
+creates a new native session from a ChatGPT or Claude web share. Use `--file`
+or `--stdin` for copied transcripts, and preview with `--dry-run`. Existing
+Codex sessions accept `--into codex:<exact-id>`; imported messages become model
+context but may not appear as normal chat bubbles. Other existing-session
+targets stay disabled until their CLIs provide a safe same-ID append contract.
 
 `showagent info <id|latest> [--yolo]` prints the exact resume command,
 working directory, and storage location for a session.
@@ -317,9 +336,11 @@ is idempotent and only installs what is missing.
 showagent itself does not upload session content and has no telemetry or
 account. An MCP client may send `get_transcript` results to that client's model
 provider, so MCP transcripts redact common secrets by default; keep that
-boundary in mind before registering the server. showagent's own HTTP client is
-used only by the optional release updater and startup update check (disable
-with `SHOWAGENT_NO_UPDATE_CHECK=1`). `showagent setup` invokes the installed
+boundary in mind before registering the server. Web import fetches only the
+public ChatGPT or Claude share URL you explicitly provide; it does not use
+browser cookies, private-chat URLs, or arbitrary hosts. The optional release
+updater and startup update check also use HTTP (disable the update check with
+`SHOWAGENT_NO_UPDATE_CHECK=1`). `showagent setup` invokes the installed
 Codex/Claude/Pi CLIs, which may download the requested plugin. Message previews
 also redact password-like strings and API keys before rendering (covered by
 tests in [`internal/session/session_test.go`](internal/session/session_test.go)).

--- a/cmd/showagent/import.go
+++ b/cmd/showagent/import.go
@@ -14,7 +14,10 @@ import (
 	"github.com/aytzey/showagent/internal/session"
 )
 
-const maxImportInputBytes = 10 * 1024 * 1024
+const (
+	maxImportInputBytes   = 10 * 1024 * 1024
+	maxImportPreviewRunes = 120
+)
 
 type importCLIOptions struct {
 	url       string
@@ -37,6 +40,8 @@ type importCLIResult struct {
 	SessionID            string `json:"session_id,omitempty"`
 	Workspace            string `json:"workspace"`
 	MessageCount         int    `json:"message_count"`
+	FirstMessage         string `json:"first_message,omitempty"`
+	LastMessage          string `json:"last_message,omitempty"`
 	NativeHistoryVisible bool   `json:"native_history_visible"`
 	NoOp                 bool   `json:"no_op,omitempty"`
 	DryRun               bool   `json:"dry_run"`
@@ -110,6 +115,8 @@ func runImport(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		result.SessionID = plan.Target.ID
 	}
 	if options.dryRun {
+		result.FirstMessage = importPreviewBoundary(conversation.Messages[0])
+		result.LastMessage = importPreviewBoundary(conversation.Messages[len(conversation.Messages)-1])
 		return printImportResult(stdout, stderr, result, options.asJSON)
 	}
 
@@ -272,6 +279,15 @@ func importWarning(mode session.ImportMode, provider session.Provider) string {
 	return "Text only. Attachments, tool state, permissions, and files are not imported."
 }
 
+func importPreviewBoundary(message importer.Message) string {
+	value := fmt.Sprintf("%s: %s", message.Role, session.RedactSecrets(session.SafeDisplayText(message.Text)))
+	runes := []rune(value)
+	if len(runes) <= maxImportPreviewRunes {
+		return value
+	}
+	return string(runes[:maxImportPreviewRunes-3]) + "..."
+}
+
 func printImportResult(stdout, stderr io.Writer, result importCLIResult, asJSON bool) int {
 	if asJSON {
 		encoder := json.NewEncoder(stdout)
@@ -297,6 +313,12 @@ func printImportResult(stdout, stderr io.Writer, result importCLIResult, asJSON 
 	}
 	_, _ = fmt.Fprintf(stdout, "  workspace: %s\n", session.SafeDisplayText(result.Workspace))
 	_, _ = fmt.Fprintf(stdout, "  content:   %d messages · text only\n", result.MessageCount)
+	if result.FirstMessage != "" {
+		_, _ = fmt.Fprintf(stdout, "  first:     %s\n", result.FirstMessage)
+	}
+	if result.LastMessage != "" {
+		_, _ = fmt.Fprintf(stdout, "  last:      %s\n", result.LastMessage)
+	}
 	if result.Warning != "" {
 		_, _ = fmt.Fprintf(stdout, "  warning:   %s\n", result.Warning)
 	}

--- a/cmd/showagent/import.go
+++ b/cmd/showagent/import.go
@@ -223,7 +223,7 @@ func loadImportConversation(ctx context.Context, options importCLIOptions, stdin
 		}
 		return importer.ImportURL(ctx, options.url, importer.FetchOptions{})
 	}
-	var reader io.Reader = stdin
+	reader := stdin
 	if options.file != "" {
 		file, err := os.Open(options.file)
 		if err != nil {

--- a/cmd/showagent/import.go
+++ b/cmd/showagent/import.go
@@ -1,0 +1,304 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aytzey/showagent/internal/importer"
+	"github.com/aytzey/showagent/internal/session"
+)
+
+const maxImportInputBytes = 10 * 1024 * 1024
+
+type importCLIOptions struct {
+	url       string
+	file      string
+	stdin     bool
+	format    string
+	asNote    bool
+	target    string
+	cwd       string
+	into      string
+	dryRun    bool
+	asJSON    bool
+	inputKind string
+}
+
+type importCLIResult struct {
+	Operation            string `json:"operation"`
+	Source               string `json:"source"`
+	Provider             string `json:"provider"`
+	SessionID            string `json:"session_id,omitempty"`
+	Workspace            string `json:"workspace"`
+	MessageCount         int    `json:"message_count"`
+	NativeHistoryVisible bool   `json:"native_history_visible"`
+	NoOp                 bool   `json:"no_op,omitempty"`
+	DryRun               bool   `json:"dry_run"`
+	Warning              string `json:"warning,omitempty"`
+}
+
+func runImport(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	options, err := parseImportArgs(args)
+	if err != nil {
+		return usageError(stderr, err.Error())
+	}
+	conversation, err := loadImportConversation(context.Background(), options, stdin)
+	if err != nil {
+		var ambiguity *importer.AmbiguityError
+		if errors.As(err, &ambiguity) {
+			return usageError(stderr, "import input: "+err.Error())
+		}
+		_, _ = fmt.Fprintf(stderr, "showagent: import input: %v\n", err)
+		return 1
+	}
+	messages := make([]session.ImportMessage, 0, len(conversation.Messages))
+	for _, message := range conversation.Messages {
+		messages = append(messages, session.ImportMessage{Role: string(message.Role), Text: message.Text})
+	}
+
+	request := session.ImportRequest{Mode: session.ImportCreate, Messages: messages}
+	if options.into != "" {
+		provider, id, err := parseImportTarget(options.into)
+		if err != nil {
+			return usageError(stderr, err.Error())
+		}
+		row, err := resolveSession(session.Discover(), id)
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "showagent: %v\n", err)
+			return 1
+		}
+		if row.Provider != provider {
+			return usageError(stderr, fmt.Sprintf("session %q belongs to %s, not %s", id, row.Provider, provider))
+		}
+		request.Mode = session.ImportAppendContext
+		request.Provider = provider
+		request.Target = row
+	} else {
+		provider, err := session.ParseProvider(options.target)
+		if err != nil {
+			return usageError(stderr, err.Error())
+		}
+		cwd, err := filepath.Abs(options.cwd)
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "showagent: resolve import workspace: %v\n", err)
+			return 1
+		}
+		request.Provider = provider
+		request.CWD = cwd
+	}
+
+	plan, err := session.PlanImport(request)
+	if err != nil {
+		return usageError(stderr, err.Error())
+	}
+	result := importCLIResult{
+		Operation:    string(plan.Mode),
+		Source:       options.inputKind,
+		Provider:     string(plan.Provider),
+		Workspace:    plan.CWD,
+		MessageCount: plan.MessageCount,
+		DryRun:       options.dryRun,
+		Warning:      importWarning(plan.Mode, plan.Provider),
+	}
+	if plan.Mode == session.ImportAppendContext {
+		result.SessionID = plan.Target.ID
+	}
+	if options.dryRun {
+		return printImportResult(stdout, stderr, result, options.asJSON)
+	}
+
+	receipt, err := session.ApplyImport(context.Background(), plan)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "showagent: import failed: %v\n", err)
+		return 1
+	}
+	result.Operation = string(receipt.Mode)
+	result.Provider = string(receipt.Provider)
+	result.SessionID = receipt.Row.ID
+	result.Workspace = receipt.Row.CWD
+	result.MessageCount = receipt.MessageCount
+	result.NativeHistoryVisible = receipt.NativeHistoryVisible
+	result.NoOp = receipt.NoOp
+	result.DryRun = false
+	return printImportResult(stdout, stderr, result, options.asJSON)
+}
+
+func parseImportArgs(args []string) (importCLIOptions, error) {
+	options := importCLIOptions{format: "auto"}
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		value := func(name string) (string, error) {
+			index++
+			if index >= len(args) || strings.TrimSpace(args[index]) == "" {
+				return "", fmt.Errorf("import %s needs a value", name)
+			}
+			return args[index], nil
+		}
+		var err error
+		switch arg {
+		case "--url":
+			options.url, err = value(arg)
+		case "--file":
+			options.file, err = value(arg)
+		case "--stdin":
+			options.stdin = true
+		case "--format":
+			options.format, err = value(arg)
+		case "--as-note":
+			options.asNote = true
+		case "--to":
+			options.target, err = value(arg)
+		case "--cwd":
+			options.cwd, err = value(arg)
+		case "--into":
+			options.into, err = value(arg)
+		case "--dry-run":
+			options.dryRun = true
+		case "--json":
+			options.asJSON = true
+		default:
+			return options, fmt.Errorf("unknown import argument %q", arg)
+		}
+		if err != nil {
+			return options, err
+		}
+	}
+	sources := 0
+	if options.url != "" {
+		sources++
+		options.inputKind = "share link"
+	}
+	if options.file != "" {
+		sources++
+		options.inputKind = "transcript file"
+	}
+	if options.stdin {
+		sources++
+		options.inputKind = "pasted text"
+	}
+	if sources != 1 {
+		return options, fmt.Errorf("import needs exactly one source: --url, --file, or --stdin")
+	}
+	if options.format != "auto" && options.format != "text" && options.format != "json" {
+		return options, fmt.Errorf("import --format must be auto, text, or json")
+	}
+	if options.asNote && options.url != "" {
+		return options, fmt.Errorf("import --as-note is only valid with text from --file or --stdin")
+	}
+	if options.asNote && (options.format == "json" || (options.format == "auto" && strings.EqualFold(filepath.Ext(options.file), ".json"))) {
+		return options, fmt.Errorf("import --as-note cannot be combined with JSON input")
+	}
+	if options.into != "" {
+		if options.target != "" || options.cwd != "" {
+			return options, fmt.Errorf("choose either --to with --cwd, or --into")
+		}
+	} else if options.target == "" || options.cwd == "" {
+		return options, fmt.Errorf("new-session import needs --to <provider> and --cwd <directory>")
+	}
+	return options, nil
+}
+
+func parseImportTarget(value string) (session.Provider, string, error) {
+	providerText, id, ok := strings.Cut(value, ":")
+	if !ok || strings.TrimSpace(providerText) == "" || strings.TrimSpace(id) == "" {
+		return "", "", fmt.Errorf("import --into needs provider:exact-session-id")
+	}
+	if id == "latest" {
+		return "", "", fmt.Errorf("import --into needs an exact session id; 'latest' is not accepted")
+	}
+	provider, err := session.ParseProvider(providerText)
+	return provider, id, err
+}
+
+func loadImportConversation(ctx context.Context, options importCLIOptions, stdin io.Reader) (importer.Conversation, error) {
+	if options.url != "" {
+		if options.format != "auto" {
+			return importer.Conversation{}, fmt.Errorf("--format is only valid with --file or --stdin")
+		}
+		return importer.ImportURL(ctx, options.url, importer.FetchOptions{})
+	}
+	var reader io.Reader = stdin
+	if options.file != "" {
+		file, err := os.Open(options.file)
+		if err != nil {
+			return importer.Conversation{}, err
+		}
+		defer func() { _ = file.Close() }()
+		reader = file
+	}
+	data, err := readImportInput(reader)
+	if err != nil {
+		return importer.Conversation{}, err
+	}
+	format := options.format
+	if format == "auto" && options.file != "" && strings.EqualFold(filepath.Ext(options.file), ".json") {
+		format = "json"
+	}
+	if format == "json" {
+		conversation, err := importer.ParseJSON(data)
+		return conversation, err
+	}
+	sourceKind := importer.SourcePastedText
+	if options.file != "" {
+		sourceKind = importer.SourceTranscriptFile
+	}
+	return importer.ParseText(string(data), importer.TextOptions{
+		AsOneContextNote: options.asNote,
+		SourceKind:       sourceKind,
+	})
+}
+
+func readImportInput(reader io.Reader) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(reader, maxImportInputBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxImportInputBytes {
+		return nil, fmt.Errorf("conversation exceeds the %d MiB input limit", maxImportInputBytes/(1024*1024))
+	}
+	return data, nil
+}
+
+func importWarning(mode session.ImportMode, provider session.Provider) string {
+	if mode == session.ImportAppendContext && provider == session.ProviderCodex {
+		return "Saved to this session's context. Imported messages may not appear as chat bubbles in Codex."
+	}
+	return "Text only. Attachments, tool state, permissions, and files are not imported."
+}
+
+func printImportResult(stdout, stderr io.Writer, result importCLIResult, asJSON bool) int {
+	if asJSON {
+		encoder := json.NewEncoder(stdout)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(result); err != nil {
+			_, _ = fmt.Fprintf(stderr, "showagent: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	heading := "import complete"
+	if result.DryRun {
+		heading = "import preview"
+	} else if result.NoOp {
+		heading = "import already complete"
+	}
+	_, _ = fmt.Fprintln(stdout, heading)
+	_, _ = fmt.Fprintf(stdout, "  source:    %s\n", result.Source)
+	_, _ = fmt.Fprintf(stdout, "  operation: %s\n", result.Operation)
+	_, _ = fmt.Fprintf(stdout, "  target:    %s\n", result.Provider)
+	if result.SessionID != "" {
+		_, _ = fmt.Fprintf(stdout, "  session:   %s\n", session.SafeDisplayText(result.SessionID))
+	}
+	_, _ = fmt.Fprintf(stdout, "  workspace: %s\n", session.SafeDisplayText(result.Workspace))
+	_, _ = fmt.Fprintf(stdout, "  content:   %d messages · text only\n", result.MessageCount)
+	if result.Warning != "" {
+		_, _ = fmt.Fprintf(stdout, "  warning:   %s\n", result.Warning)
+	}
+	return 0
+}

--- a/cmd/showagent/import.go
+++ b/cmd/showagent/import.go
@@ -34,18 +34,20 @@ type importCLIOptions struct {
 }
 
 type importCLIResult struct {
-	Operation            string `json:"operation"`
-	Source               string `json:"source"`
-	Provider             string `json:"provider"`
-	SessionID            string `json:"session_id,omitempty"`
-	Workspace            string `json:"workspace"`
-	MessageCount         int    `json:"message_count"`
-	FirstMessage         string `json:"first_message,omitempty"`
-	LastMessage          string `json:"last_message,omitempty"`
-	NativeHistoryVisible bool   `json:"native_history_visible"`
-	NoOp                 bool   `json:"no_op,omitempty"`
-	DryRun               bool   `json:"dry_run"`
-	Warning              string `json:"warning,omitempty"`
+	Operation            string                `json:"operation"`
+	Source               string                `json:"source"`
+	Provider             string                `json:"provider"`
+	SessionID            string                `json:"session_id,omitempty"`
+	Workspace            string                `json:"workspace"`
+	MessageCount         int                   `json:"message_count"`
+	FirstMessage         string                `json:"first_message,omitempty"`
+	LastMessage          string                `json:"last_message,omitempty"`
+	NativeHistoryVisible bool                  `json:"native_history_visible"`
+	NoOp                 bool                  `json:"no_op,omitempty"`
+	DryRun               bool                  `json:"dry_run"`
+	Warning              string                `json:"warning,omitempty"`
+	SourceWarnings       []importer.Warning    `json:"source_warnings,omitempty"`
+	Completeness         importer.Completeness `json:"completeness"`
 }
 
 func runImport(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
@@ -103,13 +105,15 @@ func runImport(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return usageError(stderr, err.Error())
 	}
 	result := importCLIResult{
-		Operation:    string(plan.Mode),
-		Source:       options.inputKind,
-		Provider:     string(plan.Provider),
-		Workspace:    plan.CWD,
-		MessageCount: plan.MessageCount,
-		DryRun:       options.dryRun,
-		Warning:      importWarning(plan.Mode, plan.Provider),
+		Operation:      string(plan.Mode),
+		Source:         options.inputKind,
+		Provider:       string(plan.Provider),
+		Workspace:      plan.CWD,
+		MessageCount:   plan.MessageCount,
+		DryRun:         options.dryRun,
+		Warning:        importWarning(plan.Mode, plan.Provider),
+		SourceWarnings: conversation.Warnings,
+		Completeness:   conversation.Completeness,
 	}
 	if plan.Mode == session.ImportAppendContext {
 		result.SessionID = plan.Target.ID
@@ -280,7 +284,7 @@ func importWarning(mode session.ImportMode, provider session.Provider) string {
 }
 
 func importPreviewBoundary(message importer.Message) string {
-	value := fmt.Sprintf("%s: %s", message.Role, session.RedactSecrets(session.SafeDisplayText(message.Text)))
+	value := fmt.Sprintf("%s: %s", message.Role, session.SafeDisplayText(session.RedactTranscriptText(message.Text)))
 	runes := []rune(value)
 	if len(runes) <= maxImportPreviewRunes {
 		return value
@@ -313,6 +317,10 @@ func printImportResult(stdout, stderr io.Writer, result importCLIResult, asJSON 
 	}
 	_, _ = fmt.Fprintf(stdout, "  workspace: %s\n", session.SafeDisplayText(result.Workspace))
 	_, _ = fmt.Fprintf(stdout, "  content:   %d messages · text only\n", result.MessageCount)
+	_, _ = fmt.Fprintf(stdout, "  scope:     %s\n", result.Completeness)
+	for _, warning := range result.SourceWarnings {
+		_, _ = fmt.Fprintf(stdout, "  omitted:   %s\n", warning.Summary())
+	}
 	if result.FirstMessage != "" {
 		_, _ = fmt.Fprintf(stdout, "  first:     %s\n", result.FirstMessage)
 	}

--- a/cmd/showagent/main.go
+++ b/cmd/showagent/main.go
@@ -23,7 +23,7 @@ import (
 var version = "dev"
 
 const (
-	usageLine              = "usage: showagent [list [--json] | transcript <id|latest> [--max-turns N] [--json] | resume <id|latest> [--yolo] | convert <id|latest> --to <provider> [--dry-run] | info <id|latest> | mcp [--read-only] [--allow-secrets] | update | setup]"
+	usageLine              = "usage: showagent [list [--json] | transcript <id|latest> [--max-turns N] [--json] | resume <id|latest> [--yolo] | convert <id|latest> --to <provider> [--dry-run] | import (--url URL|--file PATH|--stdin) (--to PROVIDER --cwd DIR|--into PROVIDER:ID) [--dry-run] | info <id|latest> | mcp [--read-only] [--allow-secrets] | update | setup]"
 	defaultTranscriptTurns = 50
 	maxTranscriptTurns     = 500
 )
@@ -35,6 +35,10 @@ func main() {
 // run dispatches CLI arguments and returns the process exit code. It is
 // separated from main so argument handling stays testable.
 func run(args []string, stdout, stderr io.Writer) int {
+	return runWithInput(args, os.Stdin, stdout, stderr)
+}
+
+func runWithInput(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
 		return runDefault(stdout, stderr)
 	}
@@ -54,6 +58,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return runResume(args[1:], stderr)
 	case "convert":
 		return runConvert(args[1:], stdout, stderr)
+	case "import":
+		return runImport(args[1:], stdin, stdout, stderr)
 	case "info":
 		return runInfo(args[1:], stdout, stderr)
 	case "mcp":
@@ -569,6 +575,8 @@ Usage:
                                      resume a session directly, without the picker
   showagent convert <id|latest> --to <provider> [--scope all|last:50] [--dry-run]
                                      preview or write a native session for another agent
+  showagent import (--url URL|--file PATH|--stdin) (--to <provider> --cwd DIR|--into PROVIDER:ID) [--format auto|text|json] [--as-note] [--dry-run] [--json]
+                                     import a ChatGPT/Claude share or pasted text
   showagent info <id|latest> [--yolo]
                                      print the exact resume command and storage location
   showagent mcp [--read-only] [--allow-secrets]
@@ -588,6 +596,10 @@ Flags:
   --to                               (convert) target provider: %s
   --scope                            (convert) all, or last:N / last-N
   --dry-run                          (convert) preview without writing anything
+                                     (import) parse and preview without writing a session
+  --url/--file/--stdin               (import) choose exactly one conversation source
+  --into                             (import) add context to an exact provider:session-id
+  --as-note                          (import) treat unlabelled text as one user context note
   --read-only                        (mcp) omit branch/convert tools; never write session stores
   --allow-secrets                    (mcp) return transcript values verbatim instead of redacting
 
@@ -595,7 +607,7 @@ Picker keys:
   enter resume · y yolo · space collapse group · / search · t scope
   x preview/confirm hand-off · n branch a copy · C compound · d/del delete
   p cycle preview (first/latest/both) · 1..9 toggle providers · r rescan
-  ? full help · esc clear search/overlay · q quit
+  i import a web conversation · ? full help · esc clear search/overlay · q quit
 
 Session locations:
   codex     ~/.codex/sessions, ~/.codex/multica-sessions

--- a/cmd/showagent/main_test.go
+++ b/cmd/showagent/main_test.go
@@ -659,6 +659,31 @@ func TestImportDryRunBoundariesAreSafeRedactedAndBounded(t *testing.T) {
 	}
 }
 
+func TestImportPreviewRedactsMultilinePrivateKeyBeforeFolding(t *testing.T) {
+	key := "-----BEGIN PRIVATE KEY-----\nsensitive-example-body\n-----END PRIVATE KEY-----"
+	var stdout, stderr bytes.Buffer
+	code := runWithInput([]string{"import", "--stdin", "--as-note", "--to", "codex", "--cwd", t.TempDir(), "--dry-run", "--json"},
+		strings.NewReader(key), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit=%d error=%s", code, &stderr)
+	}
+	if strings.Contains(stdout.String(), "sensitive-example-body") || !strings.Contains(stdout.String(), "redacted-private-key") {
+		t.Fatalf("unsafe preview = %s", &stdout)
+	}
+}
+
+func TestImportPrintsSourceLosses(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	data := `{"schema_version":1,"source_kind":"transcript_file","acquired_at":"2026-09-08T12:00:00Z","messages":[{"role":"assistant","text":"Retained answer"}],"warnings":[{"code":"omitted_non_text_content","count":3}],"completeness":"visible_path"}`
+	args := []string{"import", "--stdin", "--format", "json", "--to", "codex", "--cwd", t.TempDir(), "--dry-run"}
+	if code := runWithInput(args, strings.NewReader(data), &stdout, &stderr); code != 0 {
+		t.Fatalf("exit=%d error=%s", code, &stderr)
+	}
+	if !strings.Contains(stdout.String(), "3 non-text content blocks omitted") || !strings.Contains(stdout.String(), "visible_path") {
+		t.Fatalf("hidden losses: %s", &stdout)
+	}
+}
+
 func TestImportResolvesRelativeWorkspace(t *testing.T) {
 	setFixtureHomes(t)
 	root := t.TempDir()

--- a/cmd/showagent/main_test.go
+++ b/cmd/showagent/main_test.go
@@ -531,7 +531,11 @@ func TestImportTextDryRunDoesNotWriteSession(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
 	}
-	for _, want := range []string{"import preview", "transcript file", "codex", workspace, "2 messages", "text only"} {
+	for _, want := range []string{
+		"import preview", "transcript file", "codex", workspace, "2 messages", "text only",
+		"first:     user: Keep the index local.",
+		"last:      assistant: Use an embedded database.",
+	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("preview missing %q:\n%s", want, stdout.String())
 		}
@@ -561,6 +565,9 @@ func TestImportTextCreatesNativeSession(t *testing.T) {
 	}
 	if result["operation"] != "create" || result["source"] != "transcript file" || result["provider"] != "codex" || result["workspace"] != workspace || result["message_count"] != float64(2) {
 		t.Fatalf("unexpected import result: %#v", result)
+	}
+	if _, exists := result["first_message"]; exists {
+		t.Fatalf("completed import leaked dry-run boundary fields: %#v", result)
 	}
 	id, _ := result["session_id"].(string)
 	row, err := resolveSession(session.Discover(), id)
@@ -615,11 +622,40 @@ func TestImportVersionedJSONDryRunPreservesRolesWithoutWriting(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
 		t.Fatalf("output is not JSON: %v", err)
 	}
-	if result["source"] != "transcript file" || result["message_count"] != float64(2) || result["dry_run"] != true {
+	if result["source"] != "transcript file" || result["message_count"] != float64(2) || result["dry_run"] != true ||
+		result["first_message"] != "user: JSON question" || result["last_message"] != "assistant: JSON answer" {
 		t.Fatalf("unexpected JSON preview = %#v", result)
 	}
 	if after := len(session.Discover()); after != before {
 		t.Fatalf("JSON dry-run changed discovered session count: before=%d after=%d", before, after)
+	}
+}
+
+func TestImportDryRunBoundariesAreSafeRedactedAndBounded(t *testing.T) {
+	setFixtureHomes(t)
+	workspace := t.TempDir()
+	longAnswer := strings.Repeat("çok uzun yanıt ", 30)
+	input := "User:\npassword=hunter2\x1b]8;;https://example.com\x07click\x1b]8;;\x07\n\nAssistant:\n" + longAnswer
+
+	var stdout, stderr bytes.Buffer
+	code := runWithInput(
+		[]string{"import", "--stdin", "--to", "codex", "--cwd", workspace, "--dry-run", "--json"},
+		strings.NewReader(input), &stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	var result importCLIResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(result.FirstMessage, "hunter2") || strings.Contains(result.FirstMessage, "\x1b") ||
+		!strings.Contains(result.FirstMessage, "password=[redacted]") {
+		t.Fatalf("unsafe first boundary = %q", result.FirstMessage)
+	}
+	if len([]rune(result.FirstMessage)) > maxImportPreviewRunes || len([]rune(result.LastMessage)) > maxImportPreviewRunes ||
+		!strings.HasSuffix(result.LastMessage, "...") {
+		t.Fatalf("unbounded preview: first=%q last=%q", result.FirstMessage, result.LastMessage)
 	}
 }
 

--- a/cmd/showagent/main_test.go
+++ b/cmd/showagent/main_test.go
@@ -33,6 +33,7 @@ func setFixtureHomes(t *testing.T) {
 	t.Setenv("GEMINI_CLI_HOME", filepath.Join(root, "empty-gemini"))
 	t.Setenv("PI_CODING_AGENT_DIR", filepath.Join(root, "empty-pi"))
 	t.Setenv("PI_CODING_AGENT_SESSION_DIR", "")
+	t.Setenv("SHOWAGENT_STATE_DIR", filepath.Join(root, "showagent-state"))
 
 	writeFixture(t, filepath.Join(codexHome, "sessions", "2026", "06", "01", "rollout-2026-06-01T12-00-00-"+codexID+".jsonl"), `
 {"timestamp":"2026-06-01T09:00:00Z","type":"session_meta","payload":{"id":"`+codexID+`","cwd":"/work/codex"}}
@@ -515,6 +516,158 @@ func TestConvertWritesTargetAndPrintsRecipe(t *testing.T) {
 	matches, err := filepath.Glob(filepath.Join(os.Getenv("CLAUDE_HOME"), "projects", "*", "*.jsonl"))
 	if err != nil || len(matches) != 2 {
 		t.Fatalf("converted claude files = %v, %v; want original + copy", matches, err)
+	}
+}
+
+func TestImportTextDryRunDoesNotWriteSession(t *testing.T) {
+	setFixtureHomes(t)
+	workspace := t.TempDir()
+	input := filepath.Join(t.TempDir(), "conversation.txt")
+	writeFixture(t, input, "User:\nKeep the index local.\n\nAssistant:\nUse an embedded database.\n")
+	before := len(session.Discover())
+
+	var stdout, stderr bytes.Buffer
+	code := runWithInput([]string{"import", "--file", input, "--to", "codex", "--cwd", workspace, "--dry-run"}, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{"import preview", "transcript file", "codex", workspace, "2 messages", "text only"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("preview missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.Contains(stdout.String(), "source:    pasted text") {
+		t.Fatalf("file import was reported as pasted text:\n%s", stdout.String())
+	}
+	if after := len(session.Discover()); after != before {
+		t.Fatalf("dry-run changed discovered session count: before=%d after=%d", before, after)
+	}
+}
+
+func TestImportTextCreatesNativeSession(t *testing.T) {
+	setFixtureHomes(t)
+	workspace := t.TempDir()
+	input := filepath.Join(t.TempDir(), "conversation.txt")
+	writeFixture(t, input, "User:\nTürkçe karar\n\nAssistant:\n```go\n  keepIndent()\n```\n")
+
+	var stdout, stderr bytes.Buffer
+	code := runWithInput([]string{"import", "--file", input, "--to", "codex", "--cwd", workspace, "--json"}, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	var result map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, stdout.String())
+	}
+	if result["operation"] != "create" || result["source"] != "transcript file" || result["provider"] != "codex" || result["workspace"] != workspace || result["message_count"] != float64(2) {
+		t.Fatalf("unexpected import result: %#v", result)
+	}
+	id, _ := result["session_id"].(string)
+	row, err := resolveSession(session.Discover(), id)
+	if err != nil {
+		t.Fatalf("created session is not discoverable: %v", err)
+	}
+	turns, err := session.Transcript(row)
+	if err != nil || len(turns) != 2 || turns[0].Text != "Türkçe karar" || !strings.Contains(turns[1].Text, "  keepIndent()") {
+		t.Fatalf("unexpected native transcript: turns=%#v err=%v", turns, err)
+	}
+}
+
+func TestImportFromStdinAsOneContextNote(t *testing.T) {
+	setFixtureHomes(t)
+	workspace := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := runWithInput([]string{"import", "--stdin", "--as-note", "--to", "claude", "--cwd", workspace, "--json"}, strings.NewReader("Unlabelled research\n  keep this indentation\n"), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	var result map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("output is not JSON: %v", err)
+	}
+	if result["source"] != "pasted text" || result["provider"] != "claude" || result["message_count"] != float64(1) {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
+func TestImportResolvesRelativeWorkspace(t *testing.T) {
+	setFixtureHomes(t)
+	root := t.TempDir()
+	workspace := filepath.Join(root, "project")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(root)
+	input := filepath.Join(t.TempDir(), "conversation.txt")
+	writeFixture(t, input, "User:\nQuestion\n\nAssistant:\nAnswer\n")
+
+	var stdout, stderr bytes.Buffer
+	code := runWithInput([]string{"import", "--file", input, "--to", "codex", "--cwd", "project", "--json"}, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	var result map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("output is not JSON: %v", err)
+	}
+	if result["workspace"] != workspace {
+		t.Fatalf("workspace = %#v, want %q", result["workspace"], workspace)
+	}
+}
+
+func TestImportRetryReturnsVerifiedNoOp(t *testing.T) {
+	setFixtureHomes(t)
+	workspace := t.TempDir()
+	input := filepath.Join(t.TempDir(), "conversation.txt")
+	writeFixture(t, input, "User:\nKeep this once.\n")
+	args := []string{"import", "--file", input, "--to", "codex", "--cwd", workspace, "--json"}
+
+	var firstOut, firstErr bytes.Buffer
+	if code := runWithInput(args, strings.NewReader(""), &firstOut, &firstErr); code != 0 {
+		t.Fatalf("first exit=%d stderr=%s", code, firstErr.String())
+	}
+	var first map[string]any
+	if err := json.Unmarshal(firstOut.Bytes(), &first); err != nil {
+		t.Fatal(err)
+	}
+
+	var secondOut, secondErr bytes.Buffer
+	if code := runWithInput(args, strings.NewReader(""), &secondOut, &secondErr); code != 0 {
+		t.Fatalf("second exit=%d stderr=%s", code, secondErr.String())
+	}
+	var second map[string]any
+	if err := json.Unmarshal(secondOut.Bytes(), &second); err != nil {
+		t.Fatal(err)
+	}
+	if second["no_op"] != true || second["session_id"] != first["session_id"] {
+		t.Fatalf("second result=%#v, first=%#v", second, first)
+	}
+}
+
+func TestImportRejectsAmbiguousAndConflictingInput(t *testing.T) {
+	setFixtureHomes(t)
+	workspace := t.TempDir()
+	input := filepath.Join(t.TempDir(), "conversation.txt")
+	writeFixture(t, input, "No speaker labels here")
+
+	for _, test := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"ambiguous roles", []string{"import", "--file", input, "--to", "codex", "--cwd", workspace}, "no speaker"},
+		{"two sources", []string{"import", "--file", input, "--stdin", "--to", "codex", "--cwd", workspace}, "exactly one source"},
+		{"two target modes", []string{"import", "--file", input, "--to", "codex", "--cwd", workspace, "--into", "codex:" + codexID}, "either --to"},
+		{"latest append", []string{"import", "--file", input, "--as-note", "--into", "codex:latest"}, "exact session id"},
+		{"link as note", []string{"import", "--url", "https://chatgpt.com/share/12345678", "--as-note", "--to", "codex", "--cwd", workspace}, "only valid"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := runWithInput(test.args, strings.NewReader("ignored"), &stdout, &stderr)
+			if code != 2 || !strings.Contains(strings.ToLower(stderr.String()), test.want) {
+				t.Fatalf("exit=%d stderr=%q, want usage error containing %q", code, stderr.String(), test.want)
+			}
+		})
 	}
 }
 

--- a/cmd/showagent/main_test.go
+++ b/cmd/showagent/main_test.go
@@ -590,6 +590,39 @@ func TestImportFromStdinAsOneContextNote(t *testing.T) {
 	}
 }
 
+func TestImportVersionedJSONDryRunPreservesRolesWithoutWriting(t *testing.T) {
+	setFixtureHomes(t)
+	workspace := t.TempDir()
+	input := filepath.Join(t.TempDir(), "conversation.json")
+	writeFixture(t, input, `{
+  "schema_version": 1,
+  "source_kind": "transcript_file",
+  "acquired_at": "2026-09-08T12:00:00Z",
+  "messages": [
+    {"role":"user","text":"JSON question"},
+    {"role":"assistant","text":"JSON answer"}
+  ],
+  "completeness": "unknown"
+}`)
+	before := len(session.Discover())
+
+	var stdout, stderr bytes.Buffer
+	code := runWithInput([]string{"import", "--file", input, "--format", "json", "--to", "codex", "--cwd", workspace, "--dry-run", "--json"}, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	var result map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("output is not JSON: %v", err)
+	}
+	if result["source"] != "transcript file" || result["message_count"] != float64(2) || result["dry_run"] != true {
+		t.Fatalf("unexpected JSON preview = %#v", result)
+	}
+	if after := len(session.Discover()); after != before {
+		t.Fatalf("JSON dry-run changed discovered session count: before=%d after=%d", before, after)
+	}
+}
+
 func TestImportResolvesRelativeWorkspace(t *testing.T) {
 	setFixtureHomes(t)
 	root := t.TempDir()

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -27,7 +27,7 @@ Windows 11. They describe the tested local build, not a published release.
 | Labelled text file → Codex | Isolated native-session creation | Passed | Dry-run wrote nothing; two roles, Unicode and code indentation survived native rediscovery; identical retry was a verified no-op |
 | Public ChatGPT share | Live parse and dry-run | Passed | Current React Router snapshot format; two visible user/assistant messages; no session write |
 | Public Claude share | Live parse and dry-run | Passed | Current public snapshot JSON; 20 visible human/assistant messages; no session write |
-| Text → existing Codex **0.153.4** session | Actual native context injection | Passed | `thread/inject_items` kept the exact session ID and original file prefix; identical retry wrote no records; no `turn/start` or model call |
+| Text → existing Codex **0.153.4** session | Actual native context injection | Passed | Kept the exact session ID and original file prefix; identical retry wrote no records; the real app-server exchange was not instrumented for model-call observation |
 | Updated Codex session → Codex **0.153.4** | Actual native reader | Passed | `thread/read(includeTurns: true)` still loaded the session; injected context was persisted but is not claimed as visible chat bubbles |
 | Claude Code, Gemini CLI, OpenCode, jcode, Pi existing session | Context injection | Disabled | No verified same-ID, no-model native append contract is available in this build |
 
@@ -36,6 +36,11 @@ counts in the recorded command output. Public page and snapshot schemas are not
 documented as stable provider APIs, so fixture tests and fail-closed parsing do
 not guarantee future page compatibility. No private URL, browser cookie,
 credential, attachment, tool state, or model response was used.
+
+The fake app-server contract test records every requested method and verifies
+that import uses `thread/inject_items` without `turn/start`. The real Codex
+harness verifies identity, file-prefix preservation, persistence, retry
+idempotence, and native readability; it does not observe that method exchange.
 
 ### Published v0.11.3, 2026-09-07
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -17,6 +17,26 @@ test. This page distinguishes the checks we can report.
 
 ## Recorded checks
 
+### Local web-import build, 2026-09-08
+
+These checks used the unreleased `feat/web-conversation-import` branch on
+Windows 11. They describe the tested local build, not a published release.
+
+| Source / operation | Check | Result | Scope |
+|---|---|---|---|
+| Labelled text file → Codex | Isolated native-session creation | Passed | Dry-run wrote nothing; two roles, Unicode and code indentation survived native rediscovery; identical retry was a verified no-op |
+| Public ChatGPT share | Live parse and dry-run | Passed | Current React Router snapshot format; two visible user/assistant messages; no session write |
+| Public Claude share | Live parse and dry-run | Passed | Current public snapshot JSON; 20 visible human/assistant messages; no session write |
+| Text → existing Codex **0.153.4** session | Actual native context injection | Passed | `thread/inject_items` kept the exact session ID and original file prefix; identical retry wrote no records; no `turn/start` or model call |
+| Updated Codex session → Codex **0.153.4** | Actual native reader | Passed | `thread/read(includeTurns: true)` still loaded the session; injected context was persisted but is not claimed as visible chat bubbles |
+| Claude Code, Gemini CLI, OpenCode, jcode, Pi existing session | Context injection | Disabled | No verified same-ID, no-model native append contract is available in this build |
+
+The link checks used already-public conversations and returned only message
+counts in the recorded command output. Public page and snapshot schemas are not
+documented as stable provider APIs, so fixture tests and fail-closed parsing do
+not guarantee future page compatibility. No private URL, browser cookie,
+credential, attachment, tool state, or model response was used.
+
 ### Published v0.11.3, 2026-09-07
 
 The [release workflow](https://github.com/aytzey/showagent/actions/runs/34168549236)

--- a/docs/web-import.md
+++ b/docs/web-import.md
@@ -24,7 +24,8 @@ showagent import --file conversation.txt --to codex --cwd ./my-project --dry-run
 
 The preview shows the message count plus bounded, secret-redacted first and
 last message boundaries so you can catch the wrong source before anything is
-written.
+written. It also shows the source's completeness and counts of omitted non-text
+blocks or unsupported messages when available.
 
 Remove `--dry-run` to create the session. `--cwd` selects where the agent will work; the session itself remains in that agent's normal session store.
 
@@ -84,14 +85,25 @@ Do not import into a session that another Codex client is actively changing. sho
 
 Run `showagent` and press `i`, including from the empty state. Choose link or pasted text, review the parsed speakers and content boundary, then choose a new session or a supported existing-session target. For pasted text, `Ctrl+Enter` opens the preview directly. If your terminal cannot distinguish that shortcut, press `Tab` to focus **Review conversation**, then press `Enter`. Import completes before any optional resume action; imported instructions are history and are never executed during import.
 
+Pasting replaces the source conversation. Windows line endings are normalized
+once; tabs and message text are preserved. If the editor cannot represent the
+original formatting, or a paste exceeds its 8 KiB display preview, showagent
+keeps the full original for import and shows a read-only preview. To edit that
+source, paste the revised conversation. The 10 MiB input limit still applies;
+the display preview does not truncate the imported conversation.
+
+On final review, press `Tab` to focus **Apply import**, then `Enter` to save.
+`Ctrl+Enter` also applies the import. In the project-folder field, `Alt+Left`
+goes back without capturing letters from the path.
+
 ## Privacy and limits
 
 - Pasted/file input is processed locally. Link input connects directly to the supported share host; there is no scraping proxy or showagent account.
 - Share URLs can carry access tokens. showagent does not put the URL into the imported transcript or normal success output.
 - Import receipts live in the user state directory (override with `SHOWAGENT_STATE_DIR`) and contain hashes, counts, target identity, and native revisions, but no transcript text, source URL, or project path.
 - HTML, inert React Router payloads, and same-origin public snapshot JSON are parsed as data. Page scripts are not executed, redirects are revalidated, and local/private network destinations are rejected.
-- Oversized pages, text, or message lists fail instead of being silently truncated.
-- Use `--json` for a machine-readable preview or receipt. The output contains target metadata and counts, not the imported transcript or share URL.
+- Oversized pages, text, or message lists fail instead of being silently truncated. Native record-size limits are checked after JSON escaping, so some content may need smaller messages even within the text limit.
+- Use `--json` for a machine-readable preview or receipt. A dry-run includes bounded, secret-redacted first/last message previews, source completeness, omission warnings, target metadata, and counts. Success receipts exclude conversation text and share URLs.
 - `native_history_visible` describes existing-session append behavior. It is `false` for new-session imports because that capability flag does not apply to a newly created transcript.
 
 See [compatibility evidence](compatibility.md) for the distinction between format conversion, native loading, and model continuation.

--- a/docs/web-import.md
+++ b/docs/web-import.md
@@ -1,0 +1,93 @@
+# Import a ChatGPT or Claude conversation
+
+showagent can turn an accessible ChatGPT or Claude share into a native coding-agent session. You can also paste or pipe conversation text, which keeps private conversations private.
+
+An import carries the visible user and assistant text. It does not download attachments, restore files, copy tool calls, transfer permissions, or start a model response.
+
+## Preview and create a session
+
+Use explicit speaker labels in pasted text:
+
+```text
+User:
+Keep search local and offline.
+
+Assistant:
+Use an embedded index and rebuild it incrementally.
+```
+
+Preview before writing:
+
+```sh
+showagent import --file conversation.txt --to codex --cwd ./my-project --dry-run
+```
+
+Remove `--dry-run` to create the session. `--cwd` selects where the agent will work; the session itself remains in that agent's normal session store.
+
+For a readable public share link:
+
+```sh
+showagent import --url 'https://chatgpt.com/share/…' --to claude --cwd ./my-project --dry-run
+```
+
+The URL form reads only supported HTTPS share pages. It does not use browser cookies or sign in. If a link is restricted, unavailable, or its page format is not recognized, copy the text you can access and use `--file` or `--stdin` instead. A ChatGPT `/s/…` scheduled-task share and a private `/c/…` conversation are not conversation-share inputs.
+
+Unlabelled text is not silently split into alternating speakers. Import it as one historical context note when that is what you intend:
+
+```sh
+cat notes.txt | showagent import --stdin --as-note --to codex --cwd ./my-project
+```
+
+For automation, a versioned JSON input preserves roles without relying on display labels:
+
+```json
+{
+  "schema_version": 1,
+  "source_kind": "transcript_file",
+  "acquired_at": "2026-09-08T12:00:00Z",
+  "messages": [
+    {"role": "user", "text": "Keep search local."},
+    {"role": "assistant", "text": "Use an embedded index."}
+  ],
+  "completeness": "unknown"
+}
+```
+
+Pass it with `--format json`; set `acquired_at` to the time the transcript was
+captured. Use exactly one source: `--url`, `--file`, or `--stdin`.
+
+## Add to an existing Codex session
+
+Select the exact session ID; `latest` is deliberately not accepted for this operation:
+
+```sh
+showagent import --file conversation.txt --into codex:EXACT_SESSION_ID --dry-run
+showagent import --file conversation.txt --into codex:EXACT_SESSION_ID
+```
+
+This appends the messages to the existing Codex session's model context without starting a model turn. The session ID and prior stored records are retained. Imported context may not appear as separate chat bubbles in Codex's history view.
+
+showagent records a small local receipt without transcript text or the share
+URL. Repeating the same reviewed content for the same target becomes a verified
+no-op. If a previous native write may have completed but its receipt was not
+committed, showagent stops instead of blindly duplicating the messages.
+
+Existing-session import is provider-specific. showagent keeps the option unavailable for Claude Code, Gemini CLI, OpenCode, jcode, and Pi until their native interfaces can preserve the existing session safely. Creating a new session remains available for supported conversion targets.
+
+Do not import into a session that another Codex client is actively changing. showagent detects changes between preview and apply and verifies the original file prefix after the native operation, but it cannot coordinate with every external Codex process.
+
+## Interactive picker
+
+Run `showagent` and press `i`, including from the empty state. Choose link or pasted text, review the parsed speakers and content boundary, then choose a new session or a supported existing-session target. For pasted text, `Ctrl+Enter` opens the preview directly. If your terminal cannot distinguish that shortcut, press `Tab` to focus **Review conversation**, then press `Enter`. Import completes before any optional resume action; imported instructions are history and are never executed during import.
+
+## Privacy and limits
+
+- Pasted/file input is processed locally. Link input connects directly to the supported share host; there is no scraping proxy or showagent account.
+- Share URLs can carry access tokens. showagent does not put the URL into the imported transcript or normal success output.
+- Import receipts live in the user state directory (override with `SHOWAGENT_STATE_DIR`) and contain hashes, counts, target identity, and native revisions, but no transcript text, source URL, or project path.
+- HTML, inert React Router payloads, and same-origin public snapshot JSON are parsed as data. Page scripts are not executed, redirects are revalidated, and local/private network destinations are rejected.
+- Oversized pages, text, or message lists fail instead of being silently truncated.
+- Use `--json` for a machine-readable preview or receipt. The output contains target metadata and counts, not the imported transcript or share URL.
+- `native_history_visible` describes existing-session append behavior. It is `false` for new-session imports because that capability flag does not apply to a newly created transcript.
+
+See [compatibility evidence](compatibility.md) for the distinction between format conversion, native loading, and model continuation.

--- a/docs/web-import.md
+++ b/docs/web-import.md
@@ -22,6 +22,10 @@ Preview before writing:
 showagent import --file conversation.txt --to codex --cwd ./my-project --dry-run
 ```
 
+The preview shows the message count plus bounded, secret-redacted first and
+last message boundaries so you can catch the wrong source before anything is
+written.
+
 Remove `--dry-run` to create the session. `--cwd` selects where the agent will work; the session itself remains in that agent's normal session store.
 
 For a readable public share link:

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	charm.land/bubbles/v2 v2.2.1
 	charm.land/bubbletea/v2 v2.0.9
 	charm.land/lipgloss/v2 v2.0.6
+	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/modelcontextprotocol/go-sdk v1.7.0
@@ -13,7 +14,6 @@ require (
 )
 
 require (
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260811164956-006e29f97886 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect

--- a/internal/importer/chatgpt.go
+++ b/internal/importer/chatgpt.go
@@ -1,0 +1,7 @@
+package importer
+
+// ParseChatGPTHTML extracts the selected visible conversation path from JSON
+// embedded in a ChatGPT public share page. It never executes page JavaScript.
+func ParseChatGPTHTML(data []byte) (Conversation, error) {
+	return parseShareHTML(data, SourceChatGPTShare)
+}

--- a/internal/importer/claude.go
+++ b/internal/importer/claude.go
@@ -1,0 +1,7 @@
+package importer
+
+// ParseClaudeHTML extracts explicit human/assistant messages from JSON embedded
+// in a Claude public share page. It never executes page JavaScript.
+func ParseClaudeHTML(data []byte) (Conversation, error) {
+	return parseShareHTML(data, SourceClaudeShare)
+}

--- a/internal/importer/conversation.go
+++ b/internal/importer/conversation.go
@@ -1,0 +1,175 @@
+// Package importer parses user-supplied conversation transcripts and supported
+// public share pages. It deliberately has no dependency on native session stores.
+package importer
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	SchemaVersion = 1
+	MaxTextBytes  = 10 * 1024 * 1024
+	MaxHTMLBytes  = 20 * 1024 * 1024
+	MaxMessages   = 10_000
+)
+
+var (
+	ErrNoConversation             = errors.New("no conversation text found")
+	ErrInvalidUTF8                = errors.New("conversation is not valid UTF-8")
+	ErrLimitExceeded              = errors.New("import limit exceeded")
+	ErrAmbiguousRoles             = errors.New("some text has no speaker")
+	ErrInvalidJSON                = errors.New("invalid conversation JSON")
+	ErrUnsupportedSchema          = errors.New("unsupported conversation schema")
+	ErrUnsupportedURL             = errors.New("unsupported conversation share URL")
+	ErrUnsafeAddress              = errors.New("share URL resolved to a non-public address")
+	ErrFetch                      = errors.New("share page fetch failed")
+	ErrHTTPStatus                 = errors.New("share page returned an unexpected HTTP status")
+	ErrUnexpectedContent          = errors.New("share page returned unsupported content")
+	ErrRedirectLimit              = errors.New("share page redirect limit exceeded")
+	ErrConversationUnidentifiable = errors.New("the page opened, but its conversation could not be identified")
+)
+
+type SourceKind string
+
+const (
+	SourceChatGPTShare   SourceKind = "chatgpt_share"
+	SourceClaudeShare    SourceKind = "claude_share"
+	SourcePastedText     SourceKind = "pasted_text"
+	SourceTranscriptFile SourceKind = "transcript_file"
+)
+
+type Role string
+
+const (
+	RoleUser       Role = "user"
+	RoleAssistant  Role = "assistant"
+	RoleUnassigned Role = "unassigned"
+)
+
+type Completeness string
+
+const (
+	CompletenessUnknown     Completeness = "unknown"
+	CompletenessVisiblePath Completeness = "visible_path"
+)
+
+type Message struct {
+	SourceID        string     `json:"source_id,omitempty"`
+	Role            Role       `json:"role"`
+	Text            string     `json:"text"`
+	SourceTimestamp *time.Time `json:"source_timestamp,omitempty"`
+}
+
+type Warning struct {
+	Code  string `json:"code"`
+	Count int    `json:"count,omitempty"`
+}
+
+type Conversation struct {
+	SchemaVersion  int          `json:"schema_version"`
+	SourceKind     SourceKind   `json:"source_kind"`
+	AcquiredAt     time.Time    `json:"acquired_at"`
+	Title          string       `json:"title,omitempty"`
+	SourceRevision string       `json:"source_revision,omitempty"`
+	Messages       []Message    `json:"messages"`
+	Warnings       []Warning    `json:"warnings,omitempty"`
+	Completeness   Completeness `json:"completeness"`
+}
+
+// AmbiguityError preserves the parsed blocks for an interactive role review.
+// Callers may instead rerun ParseText with AsOneContextNote.
+type AmbiguityError struct {
+	UnassignedBlocks int
+	Conversation     Conversation
+}
+
+func (e *AmbiguityError) Error() string {
+	return fmt.Sprintf("%v (%d unassigned block(s)); assign roles or import as one context note", ErrAmbiguousRoles, e.UnassignedBlocks)
+}
+
+func (e *AmbiguityError) Unwrap() error { return ErrAmbiguousRoles }
+
+func normalizeLineEndings(text string) string {
+	return strings.ReplaceAll(text, "\r\n", "\n")
+}
+
+func validSourceKind(kind SourceKind) bool {
+	switch kind {
+	case SourceChatGPTShare, SourceClaudeShare, SourcePastedText, SourceTranscriptFile:
+		return true
+	default:
+		return false
+	}
+}
+
+func validRole(role Role) bool {
+	switch role {
+	case RoleUser, RoleAssistant, RoleUnassigned:
+		return true
+	default:
+		return false
+	}
+}
+
+func validateMessages(messages []Message) error {
+	if len(messages) == 0 {
+		return ErrNoConversation
+	}
+	if len(messages) > MaxMessages {
+		return fmt.Errorf("%w: messages exceed %d", ErrLimitExceeded, MaxMessages)
+	}
+
+	totalBytes := 0
+	for index := range messages {
+		message := &messages[index]
+		if !validRole(message.Role) {
+			return fmt.Errorf("message %d has unsupported role %q", index, message.Role)
+		}
+		if !utf8.ValidString(message.Text) {
+			return fmt.Errorf("message %d: %w", index, ErrInvalidUTF8)
+		}
+		if strings.TrimSpace(message.Text) == "" {
+			return fmt.Errorf("message %d: %w", index, ErrNoConversation)
+		}
+		totalBytes += len(message.Text)
+		if totalBytes > MaxTextBytes {
+			return fmt.Errorf("%w: message text exceeds %d bytes", ErrLimitExceeded, MaxTextBytes)
+		}
+	}
+	return nil
+}
+
+func countUnassigned(messages []Message) int {
+	count := 0
+	for _, message := range messages {
+		if message.Role == RoleUnassigned {
+			count++
+		}
+	}
+	return count
+}
+
+func validateConversation(conversation Conversation) error {
+	if conversation.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("%w: got %d, want %d", ErrUnsupportedSchema, conversation.SchemaVersion, SchemaVersion)
+	}
+	if !validSourceKind(conversation.SourceKind) {
+		return fmt.Errorf("unsupported source kind %q", conversation.SourceKind)
+	}
+	if conversation.AcquiredAt.IsZero() {
+		return errors.New("acquired_at is required")
+	}
+	if conversation.Completeness != CompletenessUnknown && conversation.Completeness != CompletenessVisiblePath {
+		return fmt.Errorf("unsupported completeness %q", conversation.Completeness)
+	}
+	return validateMessages(conversation.Messages)
+}
+
+// Validate checks the versioned model without modifying message text.
+func (conversation Conversation) Validate() error {
+	return validateConversation(conversation)
+}

--- a/internal/importer/conversation_test.go
+++ b/internal/importer/conversation_test.go
@@ -1,0 +1,146 @@
+package importer
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseTextPreservesContentAndRecognizesExplicitRoles(t *testing.T) {
+	input := "User: Merhaba\r\n  girintili\r\n\r\nAssistant:\r\nYanıt 🌿\r\nAssistant: devam\r\n"
+	wantTime := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+
+	conversation, err := ParseText(input, TextOptions{AcquiredAt: wantTime})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conversation.SchemaVersion != SchemaVersion || conversation.SourceKind != SourcePastedText {
+		t.Fatalf("unexpected conversation metadata: %#v", conversation)
+	}
+	if !conversation.AcquiredAt.Equal(wantTime) {
+		t.Fatalf("acquired_at = %v, want %v", conversation.AcquiredAt, wantTime)
+	}
+	if len(conversation.Messages) != 3 {
+		t.Fatalf("messages = %d, want 3: %#v", len(conversation.Messages), conversation.Messages)
+	}
+	want := []Message{
+		{Role: RoleUser, Text: "Merhaba\n  girintili\n"},
+		{Role: RoleAssistant, Text: "Yanıt 🌿"},
+		{Role: RoleAssistant, Text: "devam\n"},
+	}
+	for i := range want {
+		if conversation.Messages[i].Role != want[i].Role || conversation.Messages[i].Text != want[i].Text {
+			t.Errorf("message[%d] = %#v, want %#v", i, conversation.Messages[i], want[i])
+		}
+	}
+}
+
+func TestParseTextDoesNotTreatFencedOrQuotedLabelsAsSpeakers(t *testing.T) {
+	input := "User:\nHere is code:\n```text\nAssistant: literal\n```\n> Assistant: quoted\nAssistant:\nActual reply"
+
+	conversation, err := ParseText(input, TextOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(conversation.Messages) != 2 {
+		t.Fatalf("messages = %d, want 2: %#v", len(conversation.Messages), conversation.Messages)
+	}
+	wantUser := "Here is code:\n```text\nAssistant: literal\n```\n> Assistant: quoted"
+	if conversation.Messages[0].Text != wantUser {
+		t.Fatalf("user text = %q, want %q", conversation.Messages[0].Text, wantUser)
+	}
+	if conversation.Messages[1] != (Message{Role: RoleAssistant, Text: "Actual reply"}) {
+		t.Fatalf("assistant message = %#v", conversation.Messages[1])
+	}
+}
+
+func TestParseTextAliasesAndAmbiguity(t *testing.T) {
+	conversation, err := ParseText("preface\nHuman: question\nClaude: answer", TextOptions{})
+	var ambiguity *AmbiguityError
+	if !errors.As(err, &ambiguity) {
+		t.Fatalf("error = %v, want AmbiguityError", err)
+	}
+	if ambiguity.UnassignedBlocks != 1 || len(conversation.Messages) != 3 {
+		t.Fatalf("unexpected ambiguous parse: error=%#v conversation=%#v", ambiguity, conversation)
+	}
+	if conversation.Messages[1].Role != RoleUser || conversation.Messages[2].Role != RoleAssistant {
+		t.Fatalf("aliases were not recognized: %#v", conversation.Messages)
+	}
+
+	note, err := ParseText("preface\nHuman: question\nClaude: answer", TextOptions{AsOneContextNote: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(note.Messages) != 1 || note.Messages[0].Role != RoleUser {
+		t.Fatalf("one-context-note result = %#v", note.Messages)
+	}
+	wantNote := "[Imported conversation context from pasted text]\n\npreface\nHuman: question\nClaude: answer"
+	if note.Messages[0].Text != wantNote {
+		t.Fatalf("one-context-note text = %q, want %q", note.Messages[0].Text, wantNote)
+	}
+}
+
+func TestParseTextRejectsEmptyInvalidUTF8AndOversize(t *testing.T) {
+	if _, err := ParseText("  \n\t", TextOptions{}); !errors.Is(err, ErrNoConversation) {
+		t.Fatalf("empty error = %v", err)
+	}
+	if _, err := ParseText(string([]byte{0xff}), TextOptions{}); !errors.Is(err, ErrInvalidUTF8) {
+		t.Fatalf("UTF-8 error = %v", err)
+	}
+	if _, err := ParseText(strings.Repeat("x", MaxTextBytes+1), TextOptions{AsOneContextNote: true}); !errors.Is(err, ErrLimitExceeded) {
+		t.Fatalf("oversize error = %v", err)
+	}
+}
+
+func TestParseJSONV1StrictAndPreservesText(t *testing.T) {
+	data := []byte(`{
+  "schema_version": 1,
+  "source_kind": "transcript_file",
+  "acquired_at": "2026-09-08T12:00:00Z",
+  "title": "Plan",
+  "messages": [
+    {"source_id":"u1","role":"user","text":"line 1\r\n  line 2"},
+    {"role":"assistant","text":"yanıt 🌿"}
+  ],
+  "warnings": [],
+  "completeness": "visible_path"
+}`)
+
+	conversation, err := ParseJSON(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conversation.Messages[0].Text != "line 1\n  line 2" {
+		t.Fatalf("JSON text = %q", conversation.Messages[0].Text)
+	}
+	if conversation.Title != "Plan" || conversation.Completeness != CompletenessVisiblePath {
+		t.Fatalf("metadata not preserved: %#v", conversation)
+	}
+}
+
+func TestParseJSONRejectsWrongVersionUnknownFieldsAndUnassignedRoles(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+		want error
+	}{
+		{"version", `{"schema_version":2,"source_kind":"pasted_text","acquired_at":"2026-09-08T12:00:00Z","messages":[{"role":"user","text":"x"}],"completeness":"unknown"}`, ErrUnsupportedSchema},
+		{"unknown field", `{"schema_version":1,"source_kind":"pasted_text","acquired_at":"2026-09-08T12:00:00Z","messages":[{"role":"user","text":"x"}],"completeness":"unknown","secret":true}`, ErrInvalidJSON},
+		{"trailing value", `{"schema_version":1,"source_kind":"pasted_text","acquired_at":"2026-09-08T12:00:00Z","messages":[{"role":"user","text":"x"}],"completeness":"unknown"} {}`, ErrInvalidJSON},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := ParseJSON([]byte(test.json)); !errors.Is(err, test.want) {
+				t.Fatalf("error = %v, want %v", err, test.want)
+			}
+		})
+	}
+
+	data := []byte(`{"schema_version":1,"source_kind":"pasted_text","acquired_at":"2026-09-08T12:00:00Z","messages":[{"role":"unassigned","text":"x"}],"completeness":"unknown"}`)
+	_, err := ParseJSON(data)
+	var ambiguity *AmbiguityError
+	if !errors.As(err, &ambiguity) {
+		t.Fatalf("error = %v, want AmbiguityError", err)
+	}
+}

--- a/internal/importer/conversation_test.go
+++ b/internal/importer/conversation_test.go
@@ -144,3 +144,49 @@ func TestParseJSONRejectsWrongVersionUnknownFieldsAndUnassignedRoles(t *testing.
 		t.Fatalf("error = %v, want AmbiguityError", err)
 	}
 }
+
+func TestConversationValidateCoversThePublicSchemaContract(t *testing.T) {
+	valid := func() Conversation {
+		return Conversation{
+			SchemaVersion: SchemaVersion,
+			SourceKind:    SourceTranscriptFile,
+			AcquiredAt:    time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC),
+			Messages:      []Message{{Role: RoleUser, Text: "question"}, {Role: RoleAssistant, Text: "answer"}},
+			Completeness:  CompletenessUnknown,
+		}
+	}
+	if err := valid().Validate(); err != nil {
+		t.Fatalf("valid conversation: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*Conversation)
+		want   error
+	}{
+		{"schema", func(value *Conversation) { value.SchemaVersion++ }, ErrUnsupportedSchema},
+		{"source", func(value *Conversation) { value.SourceKind = "browser_history" }, nil},
+		{"acquired at", func(value *Conversation) { value.AcquiredAt = time.Time{} }, nil},
+		{"completeness", func(value *Conversation) { value.Completeness = "partial_guess" }, nil},
+		{"no messages", func(value *Conversation) { value.Messages = nil }, ErrNoConversation},
+		{"role", func(value *Conversation) { value.Messages[0].Role = "system" }, nil},
+		{"invalid UTF-8", func(value *Conversation) { value.Messages[0].Text = string([]byte{0xff}) }, ErrInvalidUTF8},
+		{"empty text", func(value *Conversation) { value.Messages[0].Text = " \n\t" }, ErrNoConversation},
+		{"total text limit", func(value *Conversation) { value.Messages[0].Text = strings.Repeat("x", MaxTextBytes+1) }, ErrLimitExceeded},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			conversation := valid()
+			test.mutate(&conversation)
+			err := conversation.Validate()
+			if err == nil || test.want != nil && !errors.Is(err, test.want) {
+				t.Fatalf("Validate error = %v, want %v", err, test.want)
+			}
+		})
+	}
+
+	ambiguity := &AmbiguityError{UnassignedBlocks: 2}
+	if !strings.Contains(ambiguity.Error(), "2 unassigned") || !errors.Is(ambiguity, ErrAmbiguousRoles) {
+		t.Fatalf("ambiguity contract = %q, unwrap=%v", ambiguity.Error(), errors.Unwrap(ambiguity))
+	}
+}

--- a/internal/importer/conversation_test.go
+++ b/internal/importer/conversation_test.go
@@ -145,6 +145,14 @@ func TestParseJSONRejectsWrongVersionUnknownFieldsAndUnassignedRoles(t *testing.
 	}
 }
 
+func TestParseJSONRejectsInvalidUTF8BeforeDecoding(t *testing.T) {
+	data := append([]byte(`{"schema_version":1,"source_kind":"transcript_file","acquired_at":"2026-09-08T12:00:00Z","messages":[{"role":"user","text":"`), 0xff)
+	data = append(data, []byte(`"}],"completeness":"unknown"}`)...)
+	if _, err := ParseJSON(data); !errors.Is(err, ErrInvalidUTF8) {
+		t.Fatalf("error = %v, want ErrInvalidUTF8 rather than replacement characters", err)
+	}
+}
+
 func TestConversationValidateCoversThePublicSchemaContract(t *testing.T) {
 	valid := func() Conversation {
 		return Conversation{

--- a/internal/importer/fetch.go
+++ b/internal/importer/fetch.go
@@ -111,7 +111,7 @@ func (fetcher *Fetcher) Fetch(ctx context.Context, rawURL string) (FetchedPage, 
 		}
 		return FetchedPage{}, fmt.Errorf("%w: %w", ErrFetch, err)
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 
 	if response.StatusCode < 200 || response.StatusCode > 299 {
 		return FetchedPage{}, fmt.Errorf("%w: %s", ErrHTTPStatus, response.Status)
@@ -227,7 +227,7 @@ func (fetcher *Fetcher) fetchSnapshotJSON(ctx context.Context, rawURL string) (S
 		}
 		return "", nil, fmt.Errorf("%w: %w", ErrFetch, err)
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode < 200 || response.StatusCode > 299 {
 		return "", nil, fmt.Errorf("%w: %s", ErrHTTPStatus, response.Status)
 	}

--- a/internal/importer/fetch.go
+++ b/internal/importer/fetch.go
@@ -1,0 +1,318 @@
+package importer
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultFetchTimeout = 15 * time.Second
+	defaultMaxRedirects = 3
+)
+
+type FetchOptions struct {
+	MaxResponseBytes int64
+	Timeout          time.Duration
+	MaxRedirects     int
+}
+
+type FetchedPage struct {
+	SourceKind  SourceKind
+	Body        []byte
+	ContentType string
+}
+
+type Fetcher struct {
+	options   FetchOptions
+	transport http.RoundTripper
+}
+
+func NewFetcher(options FetchOptions) *Fetcher {
+	return newFetcher(options, newSafeTransport())
+}
+
+func newFetcher(options FetchOptions, transport http.RoundTripper) *Fetcher {
+	if options.MaxResponseBytes <= 0 {
+		options.MaxResponseBytes = MaxHTMLBytes
+	} else if options.MaxResponseBytes > MaxHTMLBytes {
+		options.MaxResponseBytes = MaxHTMLBytes
+	}
+	if options.Timeout <= 0 {
+		options.Timeout = defaultFetchTimeout
+	} else if options.Timeout > defaultFetchTimeout {
+		options.Timeout = defaultFetchTimeout
+	}
+	if options.MaxRedirects <= 0 {
+		options.MaxRedirects = defaultMaxRedirects
+	} else if options.MaxRedirects > defaultMaxRedirects {
+		options.MaxRedirects = defaultMaxRedirects
+	}
+	return &Fetcher{options: options, transport: transport}
+}
+
+func FetchShare(ctx context.Context, rawURL string, options FetchOptions) (FetchedPage, error) {
+	return NewFetcher(options).Fetch(ctx, rawURL)
+}
+
+func (fetcher *Fetcher) Fetch(ctx context.Context, rawURL string) (FetchedPage, error) {
+	initialKind, parsedURL, err := validateShareURL(rawURL)
+	if err != nil {
+		return FetchedPage{}, err
+	}
+	ctx, cancel := context.WithTimeout(ctx, fetcher.options.Timeout)
+	defer cancel()
+
+	client := &http.Client{
+		Transport: fetcher.transport,
+		CheckRedirect: func(request *http.Request, via []*http.Request) error {
+			if len(via) > fetcher.options.MaxRedirects {
+				return ErrRedirectLimit
+			}
+			kind, _, err := validateShareURL(request.URL.String())
+			if err != nil {
+				return err
+			}
+			if kind != initialKind {
+				return fmt.Errorf("%w: cross-provider redirect", ErrUnsupportedURL)
+			}
+			return nil
+		},
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, parsedURL.String(), nil)
+	if err != nil {
+		return FetchedPage{}, fmt.Errorf("%w: %v", ErrFetch, err)
+	}
+	request.Header.Set("Accept", "text/html, application/xhtml+xml")
+	request.Header.Set("User-Agent", "showagent conversation importer")
+
+	response, err := client.Do(request)
+	if err != nil {
+		if response != nil && response.Body != nil {
+			_ = response.Body.Close()
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return FetchedPage{}, ctxErr
+		}
+		err = withoutRequestURL(err)
+		if errors.Is(err, ErrUnsupportedURL) || errors.Is(err, ErrRedirectLimit) || errors.Is(err, ErrUnsafeAddress) {
+			return FetchedPage{}, err
+		}
+		return FetchedPage{}, fmt.Errorf("%w: %w", ErrFetch, err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode < 200 || response.StatusCode > 299 {
+		return FetchedPage{}, fmt.Errorf("%w: %s", ErrHTTPStatus, response.Status)
+	}
+	mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if err != nil || (mediaType != "text/html" && mediaType != "application/xhtml+xml") {
+		return FetchedPage{}, fmt.Errorf("%w: %q", ErrUnexpectedContent, response.Header.Get("Content-Type"))
+	}
+	if response.ContentLength > fetcher.options.MaxResponseBytes {
+		return FetchedPage{}, fmt.Errorf("%w: response exceeds %d bytes", ErrLimitExceeded, fetcher.options.MaxResponseBytes)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, fetcher.options.MaxResponseBytes+1))
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return FetchedPage{}, ctxErr
+		}
+		return FetchedPage{}, fmt.Errorf("%w: %w", ErrFetch, err)
+	}
+	if int64(len(body)) > fetcher.options.MaxResponseBytes {
+		return FetchedPage{}, fmt.Errorf("%w: response exceeds %d bytes", ErrLimitExceeded, fetcher.options.MaxResponseBytes)
+	}
+	// The initial request and every redirect target were validated before the
+	// transport saw them. Keeping only the kind also avoids retaining a share
+	// token in the returned value.
+	return FetchedPage{SourceKind: initialKind, Body: body, ContentType: mediaType}, nil
+}
+
+func ImportURL(ctx context.Context, rawURL string, options FetchOptions) (Conversation, error) {
+	return NewFetcher(options).Import(ctx, rawURL)
+}
+
+func (fetcher *Fetcher) Import(ctx context.Context, rawURL string) (Conversation, error) {
+	page, pageErr := fetcher.Fetch(ctx, rawURL)
+	if pageErr == nil {
+		var conversation Conversation
+		switch page.SourceKind {
+		case SourceChatGPTShare:
+			conversation, pageErr = ParseChatGPTHTML(page.Body)
+		case SourceClaudeShare:
+			conversation, pageErr = ParseClaudeHTML(page.Body)
+		default:
+			return Conversation{}, ErrUnsupportedURL
+		}
+		if pageErr == nil {
+			return conversation, nil
+		}
+	}
+
+	// Current public pages load their actual snapshot from a same-origin JSON
+	// endpoint. Fetching the page first establishes the provider's normal public
+	// access path, then this derived request avoids executing page JavaScript.
+	kind, snapshot, snapshotErr := fetcher.fetchSnapshotJSON(ctx, rawURL)
+	if snapshotErr == nil {
+		if conversation, err := parseShareJSON(snapshot, kind); err == nil {
+			return conversation, nil
+		} else {
+			snapshotErr = err
+		}
+	}
+	if pageErr != nil {
+		return Conversation{}, fmt.Errorf("share page: %v; snapshot API: %w", pageErr, snapshotErr)
+	}
+	return Conversation{}, snapshotErr
+}
+
+// fetchSnapshotJSON reads the same public snapshot exposed by the share page.
+// The endpoint is derived from an already validated token and host; callers
+// cannot choose an arbitrary API path. Redirects are disabled so every network
+// destination remains covered by that validation and the safe transport.
+func (fetcher *Fetcher) fetchSnapshotJSON(ctx context.Context, rawURL string) (SourceKind, []byte, error) {
+	kind, parsedURL, err := validateShareURL(rawURL)
+	if err != nil {
+		return "", nil, err
+	}
+	token := strings.TrimPrefix(parsedURL.Path, "/share/")
+	switch kind {
+	case SourceChatGPTShare:
+		parsedURL.Path = "/backend-api/share/" + token
+	case SourceClaudeShare:
+		parsedURL.Path = "/api/chat_snapshots/" + token
+	default:
+		return "", nil, ErrUnsupportedURL
+	}
+	parsedURL.RawPath = ""
+	parsedURL.RawQuery = ""
+	parsedURL.Fragment = ""
+
+	ctx, cancel := context.WithTimeout(ctx, fetcher.options.Timeout)
+	defer cancel()
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, parsedURL.String(), nil)
+	if err != nil {
+		return "", nil, fmt.Errorf("%w: %v", ErrFetch, err)
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("User-Agent", "showagent conversation importer")
+	client := &http.Client{
+		Transport: fetcher.transport,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		if response != nil && response.Body != nil {
+			_ = response.Body.Close()
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", nil, ctxErr
+		}
+		err = withoutRequestURL(err)
+		if errors.Is(err, ErrUnsafeAddress) {
+			return "", nil, err
+		}
+		return "", nil, fmt.Errorf("%w: %w", ErrFetch, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode > 299 {
+		return "", nil, fmt.Errorf("%w: %s", ErrHTTPStatus, response.Status)
+	}
+	mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		return "", nil, fmt.Errorf("%w: %q", ErrUnexpectedContent, response.Header.Get("Content-Type"))
+	}
+	if response.ContentLength > fetcher.options.MaxResponseBytes {
+		return "", nil, fmt.Errorf("%w: snapshot exceeds %d bytes", ErrLimitExceeded, fetcher.options.MaxResponseBytes)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, fetcher.options.MaxResponseBytes+1))
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", nil, ctxErr
+		}
+		return "", nil, fmt.Errorf("%w: %w", ErrFetch, err)
+	}
+	if int64(len(body)) > fetcher.options.MaxResponseBytes {
+		return "", nil, fmt.Errorf("%w: snapshot exceeds %d bytes", ErrLimitExceeded, fetcher.options.MaxResponseBytes)
+	}
+	return kind, body, nil
+}
+
+// withoutRequestURL removes net/http's URL-bearing wrapper while preserving
+// the underlying transport or redirect error for errors.Is/errors.As callers.
+func withoutRequestURL(err error) error {
+	for {
+		var requestErr *url.Error
+		if !errors.As(err, &requestErr) || requestErr.Err == nil {
+			return err
+		}
+		err = requestErr.Err
+	}
+}
+
+type ipResolver interface {
+	LookupNetIP(context.Context, string, string) ([]netip.Addr, error)
+}
+
+type dialContextFunc func(context.Context, string, string) (net.Conn, error)
+
+func newSafeTransport() *http.Transport {
+	dialer := &net.Dialer{Timeout: 5 * time.Second, KeepAlive: 30 * time.Second}
+	return &http.Transport{
+		Proxy:                 nil,
+		DialContext:           secureDialContext(net.DefaultResolver, dialer.DialContext),
+		ForceAttemptHTTP2:     true,
+		TLSClientConfig:       &tls.Config{MinVersion: tls.VersionTLS12},
+		TLSHandshakeTimeout:   5 * time.Second,
+		ResponseHeaderTimeout: 10 * time.Second,
+		ExpectContinueTimeout: time.Second,
+		MaxIdleConns:          4,
+		MaxIdleConnsPerHost:   2,
+		IdleConnTimeout:       30 * time.Second,
+	}
+}
+
+func secureDialContext(resolver ipResolver, dial dialContextFunc) dialContextFunc {
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid dial address", ErrUnsafeAddress)
+		}
+		var addresses []netip.Addr
+		if literal, err := netip.ParseAddr(host); err == nil {
+			addresses = []netip.Addr{literal}
+		} else {
+			addresses, err = resolver.LookupNetIP(ctx, "ip", host)
+			if err != nil {
+				return nil, fmt.Errorf("DNS lookup for %q: %w", host, err)
+			}
+		}
+		if err := validatePublicIPs(addresses); err != nil {
+			return nil, err
+		}
+
+		var lastErr error
+		for _, resolved := range addresses {
+			resolved = resolved.Unmap()
+			connection, err := dial(ctx, network, net.JoinHostPort(resolved.String(), port))
+			if err == nil {
+				return connection, nil
+			}
+			lastErr = err
+		}
+		return nil, fmt.Errorf("dial failed after %s address(es): %w", strconv.Itoa(len(addresses)), lastErr)
+	}
+}

--- a/internal/importer/fetch_test.go
+++ b/internal/importer/fetch_test.go
@@ -1,0 +1,284 @@
+package importer
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
+
+func response(status int, contentType, body, location string) *http.Response {
+	header := make(http.Header)
+	if contentType != "" {
+		header.Set("Content-Type", contentType)
+	}
+	if location != "" {
+		header.Set("Location", location)
+	}
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Header:     header,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func TestFetchShareRevalidatesRedirects(t *testing.T) {
+	const secretToken = "redirect-secret-token"
+	called := 0
+	fetcher := newFetcher(FetchOptions{}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		called++
+		return response(http.StatusFound, "text/html", "", "https://evil.example/share/"+secretToken), nil
+	}))
+
+	_, err := fetcher.Fetch(context.Background(), "https://chatgpt.com/share/12345678")
+	if !errors.Is(err, ErrUnsupportedURL) {
+		t.Fatalf("redirect error = %v, want ErrUnsupportedURL", err)
+	}
+	if strings.Contains(err.Error(), secretToken) {
+		t.Fatalf("redirect error disclosed share token: %v", err)
+	}
+	var requestErr *url.Error
+	if errors.As(err, &requestErr) {
+		t.Fatalf("redirect error retained URL-bearing wrapper: %T", requestErr)
+	}
+	if called != 1 {
+		t.Fatalf("transport called %d times, want 1", called)
+	}
+}
+
+func TestFetchErrorsDoNotDiscloseShareURLs(t *testing.T) {
+	const secretToken = "transport-secret-token"
+	transportErr := errors.New("connection refused")
+	shareURL := "https://chatgpt.com/share/" + secretToken
+
+	tests := []struct {
+		name  string
+		fetch func(*Fetcher) error
+	}{
+		{
+			name: "share page",
+			fetch: func(fetcher *Fetcher) error {
+				_, err := fetcher.Fetch(context.Background(), shareURL)
+				return err
+			},
+		},
+		{
+			name: "snapshot API",
+			fetch: func(fetcher *Fetcher) error {
+				_, _, err := fetcher.fetchSnapshotJSON(context.Background(), shareURL)
+				return err
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fetcher := newFetcher(FetchOptions{}, roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return nil, transportErr
+			}))
+			err := test.fetch(fetcher)
+			if !errors.Is(err, ErrFetch) || !errors.Is(err, transportErr) {
+				t.Fatalf("error = %v, want ErrFetch and transport cause", err)
+			}
+			if strings.Contains(err.Error(), secretToken) {
+				t.Fatalf("error disclosed share token: %v", err)
+			}
+			var requestErr *url.Error
+			if errors.As(err, &requestErr) {
+				t.Fatalf("error retained URL-bearing wrapper: %T", requestErr)
+			}
+		})
+	}
+}
+
+func TestFetchShareAcceptsAllowedRedirectAndBoundsResponse(t *testing.T) {
+	called := 0
+	fetcher := newFetcher(FetchOptions{MaxResponseBytes: 16}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		called++
+		if called == 1 {
+			return response(http.StatusFound, "text/html", "", "https://chatgpt.com/share/abcdefgh"), nil
+		}
+		return response(http.StatusOK, "text/html; charset=utf-8", "<html>ok</html>", ""), nil
+	}))
+
+	page, err := fetcher.Fetch(context.Background(), "https://chatgpt.com/share/12345678")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(page.Body) != "<html>ok</html>" || page.SourceKind != SourceChatGPTShare || called != 2 {
+		t.Fatalf("page = %#v, calls = %d", page, called)
+	}
+
+	tooLarge := newFetcher(FetchOptions{MaxResponseBytes: 4}, roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return response(http.StatusOK, "text/html", "12345", ""), nil
+	}))
+	if _, err := tooLarge.Fetch(context.Background(), "https://chatgpt.com/share/12345678"); !errors.Is(err, ErrLimitExceeded) {
+		t.Fatalf("size error = %v, want ErrLimitExceeded", err)
+	}
+}
+
+func TestFetchShareStatusContentTypeCancellationAndRedirectLimit(t *testing.T) {
+	tests := []struct {
+		name      string
+		fetcher   *Fetcher
+		ctx       context.Context
+		wantError error
+	}{
+		{
+			name: "status",
+			fetcher: newFetcher(FetchOptions{}, roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return response(http.StatusForbidden, "text/html", "denied", ""), nil
+			})),
+			ctx: context.Background(), wantError: ErrHTTPStatus,
+		},
+		{
+			name: "content type",
+			fetcher: newFetcher(FetchOptions{}, roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return response(http.StatusOK, "image/png", "not an image", ""), nil
+			})),
+			ctx: context.Background(), wantError: ErrUnexpectedContent,
+		},
+		{
+			name: "network cancellation",
+			fetcher: newFetcher(FetchOptions{}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				<-request.Context().Done()
+				return nil, request.Context().Err()
+			})),
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			}(),
+			wantError: context.Canceled,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := test.fetcher.Fetch(test.ctx, "https://chatgpt.com/share/12345678"); !errors.Is(err, test.wantError) {
+				t.Fatalf("error = %v, want %v", err, test.wantError)
+			}
+		})
+	}
+
+	redirects := 0
+	fetcher := newFetcher(FetchOptions{MaxRedirects: 1, Timeout: time.Second}, roundTripFunc(func(*http.Request) (*http.Response, error) {
+		redirects++
+		return response(http.StatusFound, "text/html", "", "https://chatgpt.com/share/abcdefgh"), nil
+	}))
+	if _, err := fetcher.Fetch(context.Background(), "https://chatgpt.com/share/12345678"); !errors.Is(err, ErrRedirectLimit) {
+		t.Fatalf("redirect limit error = %v", err)
+	}
+}
+
+func TestDefaultTransportDoesNotUseEnvironmentProxy(t *testing.T) {
+	transport := newSafeTransport()
+	if transport.Proxy != nil {
+		t.Fatal("safe fetch transport must not use environment proxies")
+	}
+}
+
+type fixedResolver struct {
+	addresses []netip.Addr
+}
+
+func (resolver fixedResolver) LookupNetIP(context.Context, string, string) ([]netip.Addr, error) {
+	return resolver.addresses, nil
+}
+
+func TestSecureDialRejectsPrivateDNSAnswerBeforeDial(t *testing.T) {
+	dialed := false
+	dial := secureDialContext(fixedResolver{addresses: []netip.Addr{netip.MustParseAddr("127.0.0.1")}}, func(context.Context, string, string) (net.Conn, error) {
+		dialed = true
+		return nil, errors.New("unexpected dial")
+	})
+
+	if _, err := dial(context.Background(), "tcp", "chatgpt.com:443"); !errors.Is(err, ErrUnsafeAddress) {
+		t.Fatalf("dial error = %v, want ErrUnsafeAddress", err)
+	}
+	if dialed {
+		t.Fatal("dial ran after a private DNS answer")
+	}
+}
+
+func TestFetcherImportParsesTheFetchedSnapshot(t *testing.T) {
+	body := `<script type="application/json">{"conversation":{"title":"Shared greeting","current_node":"a1","mapping":{"a1":{"parent":null,"message":{"id":"a1","author":{"role":"assistant"},"content":{"parts":["hello"]}}}}}}</script>`
+	fetcher := newFetcher(FetchOptions{}, roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return response(http.StatusOK, "text/html", body, ""), nil
+	}))
+
+	conversation, err := fetcher.Import(context.Background(), "https://chatgpt.com/share/12345678")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(conversation.Messages) != 1 || conversation.Messages[0].Text != "hello" {
+		t.Fatalf("conversation = %#v", conversation)
+	}
+}
+
+func TestFetcherImportReadsProviderSnapshotEndpoints(t *testing.T) {
+	tests := []struct {
+		name      string
+		shareURL  string
+		wantPath  string
+		body      string
+		wantText  string
+		wantTitle string
+	}{
+		{
+			name:      "ChatGPT",
+			shareURL:  "https://chatgpt.com/share/66e6ce92-d844-8013-ba02-6907eb708caf",
+			wantPath:  "/backend-api/share/66e6ce92-d844-8013-ba02-6907eb708caf",
+			body:      `{"title":"Shared plan","current_node":"u1","mapping":{"u1":{"parent":null,"message":{"id":"m1","author":{"role":"user"},"content":{"parts":["live API question"]}}}}}`,
+			wantText:  "live API question",
+			wantTitle: "Shared plan",
+		},
+		{
+			name:      "Claude",
+			shareURL:  "https://claude.ai/share/e294f513-fdfa-4ce7-8c79-781385841023",
+			wantPath:  "/api/chat_snapshots/e294f513-fdfa-4ce7-8c79-781385841023",
+			body:      `{"uuid":"e294f513-fdfa-4ce7-8c79-781385841023","snapshot_name":"Shared research","chat_messages":[{"uuid":"m1","sender":"human","text":"live API question"}]}`,
+			wantText:  "live API question",
+			wantTitle: "Shared research",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			calls := 0
+			fetcher := newFetcher(FetchOptions{}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				calls++
+				if strings.HasPrefix(request.URL.Path, "/share/") {
+					return response(http.StatusOK, "text/html", "<html><body>client-rendered conversation</body></html>", ""), nil
+				}
+				if request.URL.Path != test.wantPath {
+					t.Fatalf("request path = %q, want %q", request.URL.Path, test.wantPath)
+				}
+				if request.Header.Get("Accept") != "application/json" {
+					t.Fatalf("Accept = %q", request.Header.Get("Accept"))
+				}
+				return response(http.StatusOK, "application/json; charset=utf-8", test.body, ""), nil
+			}))
+
+			conversation, err := fetcher.Import(context.Background(), test.shareURL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if calls != 2 || conversation.Title != test.wantTitle || len(conversation.Messages) != 1 || conversation.Messages[0].Text != test.wantText {
+				t.Fatalf("calls=%d conversation=%#v", calls, conversation)
+			}
+		})
+	}
+}

--- a/internal/importer/fetch_test.go
+++ b/internal/importer/fetch_test.go
@@ -192,10 +192,11 @@ func TestDefaultTransportDoesNotUseEnvironmentProxy(t *testing.T) {
 
 type fixedResolver struct {
 	addresses []netip.Addr
+	err       error
 }
 
 func (resolver fixedResolver) LookupNetIP(context.Context, string, string) ([]netip.Addr, error) {
-	return resolver.addresses, nil
+	return resolver.addresses, resolver.err
 }
 
 func TestSecureDialRejectsPrivateDNSAnswerBeforeDial(t *testing.T) {
@@ -210,6 +211,181 @@ func TestSecureDialRejectsPrivateDNSAnswerBeforeDial(t *testing.T) {
 	}
 	if dialed {
 		t.Fatal("dial ran after a private DNS answer")
+	}
+}
+
+func TestSecureDialHandlesAddressAndDialOutcomes(t *testing.T) {
+	sentinel := errors.New("resolver unavailable")
+	resolverFailure := secureDialContext(fixedResolver{err: sentinel}, func(context.Context, string, string) (net.Conn, error) {
+		t.Fatal("dial ran after resolver failure")
+		return nil, nil
+	})
+	if _, err := resolverFailure(context.Background(), "tcp", "chatgpt.com:443"); !errors.Is(err, sentinel) {
+		t.Fatalf("resolver error = %v, want sentinel", err)
+	}
+
+	invalidAddress := secureDialContext(fixedResolver{}, func(context.Context, string, string) (net.Conn, error) {
+		t.Fatal("dial ran for malformed address")
+		return nil, nil
+	})
+	if _, err := invalidAddress(context.Background(), "tcp", "missing-port"); !errors.Is(err, ErrUnsafeAddress) {
+		t.Fatalf("malformed address error = %v, want ErrUnsafeAddress", err)
+	}
+
+	var dialed []string
+	dialFailure := errors.New("connection refused")
+	resolved := secureDialContext(fixedResolver{addresses: []netip.Addr{
+		netip.MustParseAddr("93.184.216.34"),
+		netip.MustParseAddr("2606:2800:220:1:248:1893:25c8:1946"),
+	}}, func(_ context.Context, _ string, address string) (net.Conn, error) {
+		dialed = append(dialed, address)
+		if len(dialed) == 1 {
+			return nil, dialFailure
+		}
+		return nil, nil
+	})
+	if _, err := resolved(context.Background(), "tcp", "chatgpt.com:443"); err != nil {
+		t.Fatalf("fallback dial: %v", err)
+	}
+	if len(dialed) != 2 || dialed[0] != "93.184.216.34:443" || dialed[1] != "[2606:2800:220:1:248:1893:25c8:1946]:443" {
+		t.Fatalf("dialed addresses = %#v", dialed)
+	}
+
+	allFailed := secureDialContext(fixedResolver{addresses: []netip.Addr{netip.MustParseAddr("93.184.216.34")}}, func(context.Context, string, string) (net.Conn, error) {
+		return nil, dialFailure
+	})
+	if _, err := allFailed(context.Background(), "tcp", "chatgpt.com:443"); !errors.Is(err, dialFailure) {
+		t.Fatalf("all-address dial error = %v, want last dial failure", err)
+	}
+
+	literalDialed := ""
+	literal := secureDialContext(fixedResolver{err: errors.New("must not resolve a literal")}, func(_ context.Context, _ string, address string) (net.Conn, error) {
+		literalDialed = address
+		return nil, nil
+	})
+	if _, err := literal(context.Background(), "tcp", "93.184.216.34:443"); err != nil || literalDialed != "93.184.216.34:443" {
+		t.Fatalf("literal dial = %q, %v", literalDialed, err)
+	}
+}
+
+type failingReadCloser struct {
+	err error
+}
+
+func (reader failingReadCloser) Read([]byte) (int, error) { return 0, reader.err }
+func (failingReadCloser) Close() error                    { return nil }
+
+func TestFetcherRejectsDeclaredSizesAndBodyReadFailures(t *testing.T) {
+	readFailure := errors.New("body read failed")
+	tests := []struct {
+		name      string
+		response  *http.Response
+		wantError error
+	}{
+		{
+			name: "declared size",
+			response: &http.Response{
+				StatusCode: http.StatusOK, Status: http.StatusText(http.StatusOK),
+				Header: http.Header{"Content-Type": []string{"text/html"}},
+				Body:   io.NopCloser(strings.NewReader("small")), ContentLength: 32,
+			},
+			wantError: ErrLimitExceeded,
+		},
+		{
+			name: "body read",
+			response: &http.Response{
+				StatusCode: http.StatusOK, Status: http.StatusText(http.StatusOK),
+				Header: http.Header{"Content-Type": []string{"text/html"}},
+				Body:   failingReadCloser{err: readFailure},
+			},
+			wantError: readFailure,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fetcher := newFetcher(FetchOptions{MaxResponseBytes: 16}, roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return test.response, nil
+			}))
+			if _, err := fetcher.Fetch(context.Background(), "https://chatgpt.com/share/12345678"); !errors.Is(err, test.wantError) {
+				t.Fatalf("Fetch error = %v, want %v", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestSnapshotFetchRejectsInvalidResponsesWithoutParsing(t *testing.T) {
+	readFailure := errors.New("snapshot body read failed")
+	tests := []struct {
+		name      string
+		response  *http.Response
+		wantError error
+	}{
+		{
+			name:      "status",
+			response:  response(http.StatusNotFound, "application/json", `{}`, ""),
+			wantError: ErrHTTPStatus,
+		},
+		{
+			name:      "content type",
+			response:  response(http.StatusOK, "text/html", `{}`, ""),
+			wantError: ErrUnexpectedContent,
+		},
+		{
+			name: "declared size",
+			response: &http.Response{
+				StatusCode: http.StatusOK, Status: http.StatusText(http.StatusOK),
+				Header: http.Header{"Content-Type": []string{"application/json"}},
+				Body:   io.NopCloser(strings.NewReader(`{}`)), ContentLength: 32,
+			},
+			wantError: ErrLimitExceeded,
+		},
+		{
+			name: "body read",
+			response: &http.Response{
+				StatusCode: http.StatusOK, Status: http.StatusText(http.StatusOK),
+				Header: http.Header{"Content-Type": []string{"application/json"}},
+				Body:   failingReadCloser{err: readFailure},
+			},
+			wantError: readFailure,
+		},
+		{
+			name:      "actual size",
+			response:  response(http.StatusOK, "application/json", `{"long":"payload"}`, ""),
+			wantError: ErrLimitExceeded,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fetcher := newFetcher(FetchOptions{MaxResponseBytes: 8}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				if request.URL.Path != "/backend-api/share/12345678" {
+					t.Fatalf("snapshot path = %q", request.URL.Path)
+				}
+				return test.response, nil
+			}))
+			_, _, err := fetcher.fetchSnapshotJSON(context.Background(), "https://chatgpt.com/share/12345678")
+			if !errors.Is(err, test.wantError) {
+				t.Fatalf("snapshot error = %v, want %v", err, test.wantError)
+			}
+		})
+	}
+
+	if _, _, err := newFetcher(FetchOptions{}, roundTripFunc(func(*http.Request) (*http.Response, error) {
+		t.Fatal("transport ran for an unsupported URL")
+		return nil, nil
+	})).fetchSnapshotJSON(context.Background(), "https://example.com/share/12345678"); !errors.Is(err, ErrUnsupportedURL) {
+		t.Fatalf("unsupported snapshot URL error = %v", err)
+	}
+}
+
+func TestPublicFetchWrappersRejectUnsupportedURLs(t *testing.T) {
+	if _, err := FetchShare(context.Background(), "https://example.com/share/12345678", FetchOptions{}); !errors.Is(err, ErrUnsupportedURL) {
+		t.Fatalf("FetchShare error = %v", err)
+	}
+	if _, err := ImportURL(context.Background(), "https://example.com/share/12345678", FetchOptions{}); !errors.Is(err, ErrUnsupportedURL) {
+		t.Fatalf("ImportURL error = %v", err)
+	}
+	if fetcher := NewFetcher(FetchOptions{MaxResponseBytes: MaxHTMLBytes + 1, Timeout: time.Hour, MaxRedirects: 100}); fetcher.options.MaxResponseBytes != MaxHTMLBytes || fetcher.options.Timeout != defaultFetchTimeout || fetcher.options.MaxRedirects != defaultMaxRedirects {
+		t.Fatalf("NewFetcher did not cap options: %#v", fetcher.options)
 	}
 }
 

--- a/internal/importer/html.go
+++ b/internal/importer/html.go
@@ -147,19 +147,19 @@ func isHTMLSpace(value byte) bool {
 }
 
 func isEmbeddedJSONTag(tag []byte) bool {
-	scriptType, _ := scriptAttribute(tag, "type")
-	id, _ := scriptAttribute(tag, "id")
+	scriptType := scriptAttribute(tag, "type")
+	id := scriptAttribute(tag, "id")
 	return strings.EqualFold(scriptType, "application/json") || strings.EqualFold(id, "__NEXT_DATA__")
 }
 
-func scriptAttribute(tag []byte, wanted string) (string, bool) {
+func scriptAttribute(tag []byte, wanted string) string {
 	index := len("<script")
 	for index < len(tag) {
 		for index < len(tag) && isHTMLSpace(tag[index]) {
 			index++
 		}
 		if index >= len(tag) || tag[index] == '>' || tag[index] == '/' {
-			return "", false
+			return ""
 		}
 		nameStart := index
 		for index < len(tag) && isAttributeNameByte(tag[index]) {
@@ -199,10 +199,10 @@ func scriptAttribute(tag []byte, wanted string) (string, bool) {
 			}
 		}
 		if strings.EqualFold(name, wanted) {
-			return value, true
+			return value
 		}
 	}
-	return "", false
+	return ""
 }
 
 func isAttributeNameByte(value byte) bool {
@@ -416,7 +416,7 @@ func collectClaudeCandidates(value any, candidates *[]conversationCandidate) err
 		var valid bool
 		container, valid = conversation.(map[string]any)
 		if !valid {
-			return errors.New("Claude conversation envelope is malformed")
+			return errors.New("claude conversation envelope is malformed")
 		}
 	}
 	rawMessages, ok := container["chat_messages"].([]any)

--- a/internal/importer/html.go
+++ b/internal/importer/html.go
@@ -15,6 +15,8 @@ import (
 
 const maxEmbeddedJSONDocuments = 256
 
+var errNoTransferableText = errors.New("message contains only non-text content")
+
 type conversationCandidate struct {
 	title          string
 	sourceRevision string
@@ -475,6 +477,10 @@ func mappingCandidate(container map[string]any) (conversationCandidate, bool, er
 		}
 		message, supported, explicit, losses, err := messageFromObject(messageObject)
 		if err != nil {
+			if errors.Is(err, errNoTransferableText) {
+				candidate.warnings["omitted_non_text_content"] += losses
+				continue
+			}
 			return conversationCandidate{}, false, err
 		}
 		if !explicit || !supported {
@@ -512,7 +518,7 @@ func claudeMessageCandidate(container map[string]any, rawMessages []any) (conver
 			// content is entirely attachments, tool use, or another non-text block.
 			// Omit that turn while retaining later visible text. An empty or
 			// otherwise malformed text turn still fails closed.
-			if losses > 0 {
+			if errors.Is(err, errNoTransferableText) {
 				candidate.warnings["omitted_non_text_content"] += losses
 				continue
 			}
@@ -582,20 +588,34 @@ func textFromMessage(object map[string]any) (string, int, error) {
 		}
 		return text, 0, nil
 	}
-	text, losses, ok := textFromContent(object["content"])
+	text, losses, ok, err := textFromContent(object["content"])
+	if err != nil {
+		return "", losses, err
+	}
+	if !ok && losses > 0 {
+		return "", losses, errNoTransferableText
+	}
 	if !ok || strings.TrimSpace(text) == "" {
 		return "", losses, errors.New("user or assistant message has no identifiable text")
 	}
 	return text, losses, nil
 }
 
-func textFromContent(content any) (string, int, bool) {
+func textFromContent(content any) (string, int, bool, error) {
 	switch typed := content.(type) {
 	case string:
-		return typed, 0, true
+		return typed, 0, true, nil
 	case map[string]any:
-		if text, ok := typed["text"].(string); ok {
-			return text, 0, true
+		contentType := strings.ToLower(firstString(typed, "type", "content_type"))
+		if contentType != "" && contentType != "text" && contentType != "input_text" && contentType != "output_text" && contentType != "multimodal_text" {
+			return "", 1, false, nil
+		}
+		if rawText, exists := typed["text"]; exists {
+			text, ok := rawText.(string)
+			if !ok {
+				return "", 0, false, errors.New("message text block is malformed")
+			}
+			return text, 0, true, nil
 		}
 		if parts, ok := typed["parts"].([]any); ok {
 			return textFromContent(parts)
@@ -612,6 +632,8 @@ func textFromContent(content any) (string, int, bool) {
 				text, hasText := part["text"].(string)
 				if hasText && (partType == "" || partType == "text" || partType == "input_text" || partType == "output_text") {
 					parts = append(parts, text)
+				} else if partType == "text" || partType == "input_text" || partType == "output_text" {
+					return "", losses, false, errors.New("message text block is malformed")
 				} else {
 					losses++
 				}
@@ -620,11 +642,11 @@ func textFromContent(content any) (string, int, bool) {
 			}
 		}
 		if len(parts) > 0 {
-			return strings.Join(parts, "\n"), losses, true
+			return strings.Join(parts, "\n"), losses, true, nil
 		}
-		return "", losses, false
+		return "", losses, false, nil
 	}
-	return "", 0, false
+	return "", 0, false, nil
 }
 
 func sourceTimestamp(object map[string]any) *time.Time {

--- a/internal/importer/html.go
+++ b/internal/importer/html.go
@@ -508,6 +508,14 @@ func claudeMessageCandidate(container map[string]any, rawMessages []any) (conver
 		}
 		message, supported, explicit, losses, err := messageFromObject(messageObject)
 		if err != nil {
+			// Claude snapshots may contain a supported human/assistant turn whose
+			// content is entirely attachments, tool use, or another non-text block.
+			// Omit that turn while retaining later visible text. An empty or
+			// otherwise malformed text turn still fails closed.
+			if losses > 0 {
+				candidate.warnings["omitted_non_text_content"] += losses
+				continue
+			}
 			return conversationCandidate{}, false, err
 		}
 		if !explicit {

--- a/internal/importer/html.go
+++ b/internal/importer/html.go
@@ -612,7 +612,7 @@ func textFromContent(content any) (string, int, bool) {
 			}
 		}
 		if len(parts) > 0 {
-			return strings.Join(parts, ""), losses, true
+			return strings.Join(parts, "\n"), losses, true
 		}
 		return "", losses, false
 	}

--- a/internal/importer/html.go
+++ b/internal/importer/html.go
@@ -1,0 +1,704 @@
+package importer
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+const maxEmbeddedJSONDocuments = 256
+
+type conversationCandidate struct {
+	title          string
+	sourceRevision string
+	messages       []Message
+	warnings       map[string]int
+	completeness   Completeness
+}
+
+func parseShareHTML(data []byte, source SourceKind) (Conversation, error) {
+	if len(data) > MaxHTMLBytes {
+		return Conversation{}, fmt.Errorf("%w: HTML exceeds %d bytes", ErrLimitExceeded, MaxHTMLBytes)
+	}
+	if !utf8.Valid(data) {
+		return Conversation{}, ErrInvalidUTF8
+	}
+	documents := embeddedJSONDocuments(data)
+	if len(documents) == 0 {
+		return Conversation{}, ErrConversationUnidentifiable
+	}
+	return parseShareDocuments(documents, source)
+}
+
+func parseShareJSON(data []byte, source SourceKind) (Conversation, error) {
+	if len(data) > MaxHTMLBytes {
+		return Conversation{}, fmt.Errorf("%w: snapshot JSON exceeds %d bytes", ErrLimitExceeded, MaxHTMLBytes)
+	}
+	if !utf8.Valid(data) {
+		return Conversation{}, ErrInvalidUTF8
+	}
+	document, ok := decodeJSONValue(data)
+	if !ok {
+		return Conversation{}, ErrConversationUnidentifiable
+	}
+	return parseShareDocuments([]any{document}, source)
+}
+
+func parseShareDocuments(documents []any, source SourceKind) (Conversation, error) {
+	var candidates []conversationCandidate
+	for _, document := range documents {
+		var err error
+		switch source {
+		case SourceChatGPTShare:
+			err = walkChatGPTJSON(document, 0, &candidates)
+		case SourceClaudeShare:
+			err = collectClaudeCandidates(document, &candidates)
+		default:
+			return Conversation{}, ErrConversationUnidentifiable
+		}
+		if err != nil {
+			return Conversation{}, fmt.Errorf("%w: %v", ErrConversationUnidentifiable, err)
+		}
+	}
+	candidates = uniqueCandidates(candidates)
+	if len(candidates) != 1 {
+		return Conversation{}, ErrConversationUnidentifiable
+	}
+	candidate := candidates[0]
+	if err := validateMessages(candidate.messages); err != nil {
+		return Conversation{}, err
+	}
+
+	return Conversation{
+		SchemaVersion:  SchemaVersion,
+		SourceKind:     source,
+		AcquiredAt:     time.Now().UTC(),
+		Title:          candidate.title,
+		SourceRevision: candidate.sourceRevision,
+		Messages:       candidate.messages,
+		Warnings:       warningList(candidate.warnings),
+		Completeness:   candidate.completeness,
+	}, nil
+}
+
+func embeddedJSONDocuments(data []byte) []any {
+	lower := bytes.ToLower(data)
+	var documents []any
+	for offset := 0; offset < len(data) && len(documents) < maxEmbeddedJSONDocuments; {
+		relative := bytes.Index(lower[offset:], []byte("<script"))
+		if relative < 0 {
+			break
+		}
+		start := offset + relative
+		afterName := start + len("<script")
+		if afterName < len(data) && !isHTMLSpace(data[afterName]) && data[afterName] != '>' {
+			offset = afterName
+			continue
+		}
+		openEnd := findTagEnd(data, afterName)
+		if openEnd < 0 {
+			break
+		}
+		closeRelative := bytes.Index(lower[openEnd+1:], []byte("</script"))
+		if closeRelative < 0 {
+			break
+		}
+		closeStart := openEnd + 1 + closeRelative
+		tag := data[start : openEnd+1]
+		body := bytes.TrimSpace(data[openEnd+1 : closeStart])
+		if isEmbeddedJSONTag(tag) {
+			if document, ok := decodeJSONValue(body); ok {
+				documents = append(documents, document)
+			}
+		} else if document, ok := decodeKnownJSONAssignment(body); ok {
+			documents = append(documents, document)
+		} else if document, ok := decodeReactRouterEnqueue(body); ok {
+			documents = append(documents, document)
+		}
+		offset = closeStart + len("</script")
+	}
+	return documents
+}
+
+func findTagEnd(data []byte, start int) int {
+	var quote byte
+	for index := start; index < len(data); index++ {
+		switch {
+		case quote != 0 && data[index] == quote:
+			quote = 0
+		case quote == 0 && (data[index] == '\'' || data[index] == '"'):
+			quote = data[index]
+		case quote == 0 && data[index] == '>':
+			return index
+		}
+	}
+	return -1
+}
+
+func isHTMLSpace(value byte) bool {
+	return value == ' ' || value == '\t' || value == '\r' || value == '\n' || value == '\f'
+}
+
+func isEmbeddedJSONTag(tag []byte) bool {
+	scriptType, _ := scriptAttribute(tag, "type")
+	id, _ := scriptAttribute(tag, "id")
+	return strings.EqualFold(scriptType, "application/json") || strings.EqualFold(id, "__NEXT_DATA__")
+}
+
+func scriptAttribute(tag []byte, wanted string) (string, bool) {
+	index := len("<script")
+	for index < len(tag) {
+		for index < len(tag) && isHTMLSpace(tag[index]) {
+			index++
+		}
+		if index >= len(tag) || tag[index] == '>' || tag[index] == '/' {
+			return "", false
+		}
+		nameStart := index
+		for index < len(tag) && isAttributeNameByte(tag[index]) {
+			index++
+		}
+		if nameStart == index {
+			index++
+			continue
+		}
+		name := string(tag[nameStart:index])
+		for index < len(tag) && isHTMLSpace(tag[index]) {
+			index++
+		}
+		value := ""
+		if index < len(tag) && tag[index] == '=' {
+			index++
+			for index < len(tag) && isHTMLSpace(tag[index]) {
+				index++
+			}
+			if index < len(tag) && (tag[index] == '\'' || tag[index] == '"') {
+				quote := tag[index]
+				index++
+				valueStart := index
+				for index < len(tag) && tag[index] != quote {
+					index++
+				}
+				value = string(tag[valueStart:index])
+				if index < len(tag) {
+					index++
+				}
+			} else {
+				valueStart := index
+				for index < len(tag) && !isHTMLSpace(tag[index]) && tag[index] != '>' {
+					index++
+				}
+				value = string(tag[valueStart:index])
+			}
+		}
+		if strings.EqualFold(name, wanted) {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+func isAttributeNameByte(value byte) bool {
+	return value >= 'a' && value <= 'z' || value >= 'A' && value <= 'Z' || value >= '0' && value <= '9' || value == '_' || value == '-' || value == ':'
+}
+
+func decodeJSONValue(data []byte) (any, bool) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, false
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return nil, false
+	}
+	return value, true
+}
+
+func decodeKnownJSONAssignment(data []byte) (any, bool) {
+	markers := []string{"__NEXT_DATA__", "__INITIAL_STATE__", "__CLAUDE_STATE__", "__remixContext"}
+	text := string(data)
+	for _, marker := range markers {
+		markerIndex := strings.Index(text, marker)
+		if markerIndex < 0 {
+			continue
+		}
+		equals := strings.IndexByte(text[markerIndex+len(marker):], '=')
+		if equals < 0 {
+			continue
+		}
+		start := markerIndex + len(marker) + equals + 1
+		decoder := json.NewDecoder(strings.NewReader(text[start:]))
+		decoder.UseNumber()
+		var value any
+		if decoder.Decode(&value) == nil {
+			return value, true
+		}
+	}
+	return nil, false
+}
+
+// decodeReactRouterEnqueue handles the inert, index-deduplicated snapshot used
+// by current ChatGPT share pages. It decodes JSON strings and references only;
+// no JavaScript is evaluated.
+func decodeReactRouterEnqueue(data []byte) (any, bool) {
+	const marker = "window.__reactRouterContext.streamController.enqueue("
+	text := string(data)
+	index := strings.Index(text, marker)
+	if index < 0 {
+		return nil, false
+	}
+	decoder := json.NewDecoder(strings.NewReader(text[index+len(marker):]))
+	var payload string
+	if err := decoder.Decode(&payload); err != nil {
+		return nil, false
+	}
+	flattened, ok := decodeJSONValue([]byte(payload))
+	if !ok {
+		return nil, false
+	}
+	table, ok := flattened.([]any)
+	if !ok || len(table) == 0 || len(table) > 200_000 {
+		return nil, false
+	}
+	document, err := newFlattenedJSONDecoder(table).decodeIndex(0, 0)
+	return document, err == nil
+}
+
+type flattenedJSONDecoder struct {
+	table   []any
+	state   []uint8
+	decoded []any
+}
+
+func newFlattenedJSONDecoder(table []any) *flattenedJSONDecoder {
+	return &flattenedJSONDecoder{
+		table:   table,
+		state:   make([]uint8, len(table)),
+		decoded: make([]any, len(table)),
+	}
+}
+
+func (decoder *flattenedJSONDecoder) decodeIndex(index, depth int) (any, error) {
+	if index < 0 {
+		// Negative indexes are serializer sentinels such as null/undefined. None
+		// can contain conversation messages, so treating them as nil is safe.
+		return nil, nil
+	}
+	if index >= len(decoder.table) || depth > 128 {
+		return nil, errors.New("flattened JSON reference is invalid")
+	}
+	switch decoder.state[index] {
+	case 1:
+		// Shared/cyclic metadata outside the transcript is irrelevant to the
+		// conversation candidate and cannot be represented in the returned JSON
+		// tree. Break that reference rather than rejecting the whole snapshot.
+		return nil, nil
+	case 2:
+		return decoder.decoded[index], nil
+	}
+	decoder.state[index] = 1
+	value, err := decoder.decodeValue(decoder.table[index], depth+1)
+	if err != nil {
+		return nil, err
+	}
+	decoder.decoded[index] = value
+	decoder.state[index] = 2
+	return value, nil
+}
+
+func (decoder *flattenedJSONDecoder) decodeValue(raw any, depth int) (any, error) {
+	switch typed := raw.(type) {
+	case map[string]any:
+		value := make(map[string]any, len(typed))
+		for encodedKey, encodedValue := range typed {
+			if !strings.HasPrefix(encodedKey, "_") {
+				value[encodedKey] = encodedValue
+				continue
+			}
+			keyIndex, err := strconv.Atoi(strings.TrimPrefix(encodedKey, "_"))
+			if err != nil {
+				return nil, errors.New("flattened JSON object key reference is invalid")
+			}
+			decodedKey, err := decoder.decodeIndex(keyIndex, depth+1)
+			if err != nil {
+				return nil, err
+			}
+			key, ok := decodedKey.(string)
+			if !ok {
+				continue
+			}
+			decodedValue, err := decoder.decodeReference(encodedValue, depth+1)
+			if err != nil {
+				return nil, err
+			}
+			value[key] = decodedValue
+		}
+		return value, nil
+	case []any:
+		value := make([]any, len(typed))
+		for index, item := range typed {
+			decoded, err := decoder.decodeReference(item, depth+1)
+			if err != nil {
+				return nil, err
+			}
+			value[index] = decoded
+		}
+		return value, nil
+	default:
+		return raw, nil
+	}
+}
+
+func (decoder *flattenedJSONDecoder) decodeReference(raw any, depth int) (any, error) {
+	reference, ok := raw.(json.Number)
+	if !ok {
+		return raw, nil
+	}
+	index, err := strconv.Atoi(reference.String())
+	if err != nil {
+		return nil, errors.New("flattened JSON value reference is not an integer")
+	}
+	return decoder.decodeIndex(index, depth+1)
+}
+
+// walkChatGPTJSON searches only for ChatGPT's selected mapping envelope. Share
+// pages can nest that envelope under Next.js or React Router loader data, but a
+// generic messages array elsewhere in the page is not a conversation signal.
+func walkChatGPTJSON(value any, depth int, candidates *[]conversationCandidate) error {
+	if depth > 64 || len(*candidates) > maxEmbeddedJSONDocuments {
+		return errors.New("embedded JSON nesting or candidate limit exceeded")
+	}
+	switch typed := value.(type) {
+	case map[string]any:
+		if candidate, found, err := mappingCandidate(typed); err != nil {
+			return err
+		} else if found {
+			*candidates = append(*candidates, candidate)
+		}
+		for key, child := range typed {
+			if key == "mapping" {
+				continue
+			}
+			if err := walkChatGPTJSON(child, depth+1, candidates); err != nil {
+				return err
+			}
+		}
+	case []any:
+		for _, child := range typed {
+			if err := walkChatGPTJSON(child, depth+1, candidates); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// collectClaudeCandidates accepts only the two public Claude shapes we know:
+// a snapshot object with chat_messages, or a top-level conversation envelope
+// containing that snapshot. It intentionally does not recursively discover
+// chat_messages in unrelated application state.
+func collectClaudeCandidates(value any, candidates *[]conversationCandidate) error {
+	root, ok := value.(map[string]any)
+	if !ok {
+		return nil
+	}
+	container := root
+	if conversation, exists := root["conversation"]; exists {
+		var valid bool
+		container, valid = conversation.(map[string]any)
+		if !valid {
+			return errors.New("Claude conversation envelope is malformed")
+		}
+	}
+	rawMessages, ok := container["chat_messages"].([]any)
+	if !ok {
+		return nil
+	}
+	candidate, found, err := claudeMessageCandidate(container, rawMessages)
+	if err != nil {
+		return err
+	}
+	if found {
+		*candidates = append(*candidates, candidate)
+	}
+	return nil
+}
+
+func mappingCandidate(container map[string]any) (conversationCandidate, bool, error) {
+	mapping, ok := container["mapping"].(map[string]any)
+	if !ok || len(mapping) == 0 {
+		return conversationCandidate{}, false, nil
+	}
+	selected := firstString(container, "current_node", "currentNode")
+	if selected == "" {
+		return conversationCandidate{}, false, nil
+	}
+
+	var reversed []map[string]any
+	seen := make(map[string]bool)
+	for selected != "" {
+		if seen[selected] || len(seen) > MaxMessages {
+			return conversationCandidate{}, false, errors.New("mapping path contains a cycle or exceeds the message limit")
+		}
+		seen[selected] = true
+		node, ok := mapping[selected].(map[string]any)
+		if !ok {
+			return conversationCandidate{}, false, errors.New("selected mapping path is incomplete")
+		}
+		reversed = append(reversed, node)
+		selected = firstString(node, "parent")
+	}
+
+	candidate := conversationCandidate{
+		title:          firstString(container, "title", "name", "snapshot_name"),
+		sourceRevision: firstString(container, "source_revision", "revision", "uuid"),
+		warnings:       make(map[string]int),
+		completeness:   CompletenessVisiblePath,
+	}
+	for index := len(reversed) - 1; index >= 0; index-- {
+		rawMessage, exists := reversed[index]["message"]
+		if !exists || rawMessage == nil {
+			continue
+		}
+		messageObject, ok := rawMessage.(map[string]any)
+		if !ok {
+			return conversationCandidate{}, false, errors.New("mapping message is malformed")
+		}
+		message, supported, explicit, losses, err := messageFromObject(messageObject)
+		if err != nil {
+			return conversationCandidate{}, false, err
+		}
+		if !explicit || !supported {
+			candidate.warnings["omitted_unsupported_roles"]++
+			continue
+		}
+		if losses > 0 {
+			candidate.warnings["omitted_non_text_content"] += losses
+		}
+		candidate.messages = append(candidate.messages, message)
+	}
+	if len(candidate.messages) == 0 {
+		return conversationCandidate{}, false, errors.New("selected mapping path has no user or assistant text")
+	}
+	return candidate, true, nil
+}
+
+func claudeMessageCandidate(container map[string]any, rawMessages []any) (conversationCandidate, bool, error) {
+	candidate := conversationCandidate{
+		title:          firstString(container, "title", "name", "snapshot_name"),
+		sourceRevision: firstString(container, "source_revision", "revision", "uuid"),
+		warnings:       make(map[string]int),
+		completeness:   CompletenessVisiblePath,
+	}
+	recognized := false
+	for _, rawMessage := range rawMessages {
+		messageObject, ok := rawMessage.(map[string]any)
+		if !ok {
+			candidate.warnings["omitted_non_text_content"]++
+			continue
+		}
+		message, supported, explicit, losses, err := messageFromObject(messageObject)
+		if err != nil {
+			return conversationCandidate{}, false, err
+		}
+		if !explicit {
+			candidate.warnings["omitted_non_text_content"]++
+			continue
+		}
+		if !supported {
+			candidate.warnings["omitted_unsupported_roles"]++
+			continue
+		}
+		recognized = true
+		if losses > 0 {
+			candidate.warnings["omitted_non_text_content"] += losses
+		}
+		candidate.messages = append(candidate.messages, message)
+	}
+	if !recognized {
+		return conversationCandidate{}, false, nil
+	}
+	return candidate, true, nil
+}
+
+func messageFromObject(object map[string]any) (Message, bool, bool, int, error) {
+	roleName := firstString(object, "role", "sender")
+	if roleName == "" {
+		if author, ok := object["author"].(map[string]any); ok {
+			roleName = firstString(author, "role")
+		}
+	}
+	if roleName == "" {
+		return Message{}, false, false, 0, nil
+	}
+	role, supported := importedRole(roleName)
+	if !supported {
+		return Message{}, false, true, 0, nil
+	}
+	text, losses, err := textFromMessage(object)
+	if err != nil {
+		return Message{}, false, true, losses, err
+	}
+	return Message{
+		SourceID:        firstString(object, "id", "uuid", "message_id"),
+		Role:            role,
+		Text:            normalizeLineEndings(text),
+		SourceTimestamp: sourceTimestamp(object),
+	}, true, true, losses, nil
+}
+
+func importedRole(raw string) (Role, bool) {
+	switch strings.ToLower(raw) {
+	case "user", "human":
+		return RoleUser, true
+	case "assistant", "chatgpt", "claude":
+		return RoleAssistant, true
+	default:
+		return "", false
+	}
+}
+
+func textFromMessage(object map[string]any) (string, int, error) {
+	if text, ok := object["text"].(string); ok {
+		if strings.TrimSpace(text) == "" {
+			return "", 0, errors.New("message has empty text")
+		}
+		return text, 0, nil
+	}
+	text, losses, ok := textFromContent(object["content"])
+	if !ok || strings.TrimSpace(text) == "" {
+		return "", losses, errors.New("user or assistant message has no identifiable text")
+	}
+	return text, losses, nil
+}
+
+func textFromContent(content any) (string, int, bool) {
+	switch typed := content.(type) {
+	case string:
+		return typed, 0, true
+	case map[string]any:
+		if text, ok := typed["text"].(string); ok {
+			return text, 0, true
+		}
+		if parts, ok := typed["parts"].([]any); ok {
+			return textFromContent(parts)
+		}
+	case []any:
+		var parts []string
+		losses := 0
+		for _, rawPart := range typed {
+			switch part := rawPart.(type) {
+			case string:
+				parts = append(parts, part)
+			case map[string]any:
+				partType := strings.ToLower(firstString(part, "type", "content_type"))
+				text, hasText := part["text"].(string)
+				if hasText && (partType == "" || partType == "text" || partType == "input_text" || partType == "output_text") {
+					parts = append(parts, text)
+				} else {
+					losses++
+				}
+			default:
+				losses++
+			}
+		}
+		if len(parts) > 0 {
+			return strings.Join(parts, ""), losses, true
+		}
+		return "", losses, false
+	}
+	return "", 0, false
+}
+
+func sourceTimestamp(object map[string]any) *time.Time {
+	for _, key := range []string{"source_timestamp", "created_at", "create_time", "timestamp"} {
+		raw, exists := object[key]
+		if !exists {
+			continue
+		}
+		switch value := raw.(type) {
+		case string:
+			if parsed, err := time.Parse(time.RFC3339Nano, value); err == nil {
+				parsed = parsed.UTC()
+				return &parsed
+			}
+		case json.Number:
+			if seconds, err := strconv.ParseFloat(string(value), 64); err == nil {
+				return unixFloatTime(seconds)
+			}
+		case float64:
+			return unixFloatTime(value)
+		}
+	}
+	return nil
+}
+
+func unixFloatTime(value float64) *time.Time {
+	seconds := int64(value)
+	nanoseconds := int64((value - float64(seconds)) * float64(time.Second))
+	parsed := time.Unix(seconds, nanoseconds).UTC()
+	return &parsed
+}
+
+func firstString(object map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value, ok := object[key].(string); ok {
+			return value
+		}
+	}
+	return ""
+}
+
+func uniqueCandidates(candidates []conversationCandidate) []conversationCandidate {
+	seen := make(map[string]int)
+	unique := make([]conversationCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		key := candidateKey(candidate)
+		if existing, ok := seen[key]; ok {
+			if unique[existing].title == "" {
+				unique[existing].title = candidate.title
+			}
+			continue
+		}
+		seen[key] = len(unique)
+		unique = append(unique, candidate)
+	}
+	return unique
+}
+
+func candidateKey(candidate conversationCandidate) string {
+	var key strings.Builder
+	for _, message := range candidate.messages {
+		key.WriteString(string(message.Role))
+		key.WriteByte(0)
+		key.WriteString(message.SourceID)
+		key.WriteByte(0)
+		key.WriteString(message.Text)
+		key.WriteByte(0xff)
+	}
+	return key.String()
+}
+
+func warningList(counts map[string]int) []Warning {
+	keys := make([]string, 0, len(counts))
+	for key, count := range counts {
+		if count > 0 {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	warnings := make([]Warning, 0, len(keys))
+	for _, key := range keys {
+		warnings = append(warnings, Warning{Code: key, Count: counts[key]})
+	}
+	return warnings
+}

--- a/internal/importer/html_test.go
+++ b/internal/importer/html_test.go
@@ -1,0 +1,157 @@
+package importer
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestParseChatGPTHTMLUsesOnlySelectedMappingPath(t *testing.T) {
+	html := []byte(`<!doctype html><html><head><title>shell title</title></head><body>
+<script id="__NEXT_DATA__" type="application/json">{
+  "props":{"pageProps":{"sharedConversation":{
+    "title":"Selected plan",
+    "current_node":"a2",
+    "mapping":{
+      "root":{"id":"root","parent":null,"message":null},
+      "u1":{"id":"u1","parent":"root","message":{"id":"m-u1","author":{"role":"user"},"create_time":1700000000,"content":{"content_type":"text","parts":["Question\n  code"]}}},
+      "a1":{"id":"a1","parent":"u1","message":{"id":"m-a1","author":{"role":"assistant"},"content":{"parts":["Hidden branch"]}}},
+      "a2":{"id":"a2","parent":"u1","message":{"id":"m-a2","author":{"role":"assistant"},"content":{"parts":["Chosen answer"]}}}
+    }
+  }}}
+}</script></body></html>`)
+
+	conversation, err := ParseChatGPTHTML(html)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conversation.Title != "Selected plan" || conversation.SourceKind != SourceChatGPTShare {
+		t.Fatalf("metadata = %#v", conversation)
+	}
+	if len(conversation.Messages) != 2 || conversation.Messages[0].Text != "Question\n  code" || conversation.Messages[1].Text != "Chosen answer" {
+		t.Fatalf("selected messages = %#v", conversation.Messages)
+	}
+	if conversation.Messages[0].SourceTimestamp == nil || conversation.Messages[0].SourceTimestamp.Unix() != 1700000000 {
+		t.Fatalf("source timestamp = %#v", conversation.Messages[0].SourceTimestamp)
+	}
+}
+
+func TestParseClaudeHTMLReadsExplicitMessageArrayAndSkipsNonTextBlocks(t *testing.T) {
+	html := []byte(`<script type="application/json">{
+  "conversation": {
+    "name":"Claude plan",
+    "chat_messages":[
+      {"uuid":"u1","sender":"human","created_at":"2026-09-08T12:00:00Z","content":[{"type":"text","text":"Merhaba"},{"type":"attachment","name":"secret.pdf"}]},
+      {"uuid":"a1","sender":"assistant","content":[{"type":"text","text":"Yanıt\n  kod"}]},
+      {"uuid":"tool1","sender":"tool","content":[{"type":"text","text":"must not import"}]}
+    ]
+  }
+}</script>`)
+
+	conversation, err := ParseClaudeHTML(html)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conversation.Title != "Claude plan" || conversation.SourceKind != SourceClaudeShare {
+		t.Fatalf("metadata = %#v", conversation)
+	}
+	if len(conversation.Messages) != 2 || conversation.Messages[0].Role != RoleUser || conversation.Messages[1].Text != "Yanıt\n  kod" {
+		t.Fatalf("messages = %#v", conversation.Messages)
+	}
+	if len(conversation.Warnings) == 0 {
+		t.Fatal("expected a warning for omitted non-message content")
+	}
+}
+
+func TestParseShareHTMLFailsClosed(t *testing.T) {
+	tests := []struct {
+		name string
+		html string
+	}{
+		{"no json", `<html><body><nav>User settings</nav><p>Assistant</p></body></html>`},
+		{"unrelated json", `<script type="application/json">{"menu":{"role":"user","content":"Settings"}}</script>`},
+		{"invalid json", `<script type="application/json">{"messages":[}</script>`},
+		{"multiple conversations", `<script type="application/json">{"a":{"messages":[{"role":"user","content":"one"}]},"b":{"messages":[{"role":"user","content":"two"}]}}</script>`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := ParseChatGPTHTML([]byte(test.html)); !errors.Is(err, ErrConversationUnidentifiable) {
+				t.Fatalf("error = %v, want ErrConversationUnidentifiable", err)
+			}
+		})
+	}
+}
+
+func TestParseShareHTMLIgnoresUnrelatedNestedMessageArrays(t *testing.T) {
+	html := []byte(`<script type="application/json">{
+  "props": {
+    "analytics": {
+      "messages": [
+        {"role":"user","content":"tracking payload"},
+        {"role":"assistant","content":"not a shared conversation"}
+      ]
+    }
+  }
+}</script>`)
+
+	if _, err := ParseChatGPTHTML(html); !errors.Is(err, ErrConversationUnidentifiable) {
+		t.Fatalf("error = %v, want ErrConversationUnidentifiable", err)
+	}
+}
+
+func TestParseClaudeHTMLRejectsNestedChatMessagesOutsideKnownEnvelope(t *testing.T) {
+	html := []byte(`<script type="application/json">{
+  "application_state": {
+    "chat_messages": [
+      {"sender":"human","text":"not a public snapshot"},
+      {"sender":"assistant","text":"must not import"}
+    ]
+  }
+}</script>`)
+
+	if _, err := ParseClaudeHTML(html); !errors.Is(err, ErrConversationUnidentifiable) {
+		t.Fatalf("error = %v, want ErrConversationUnidentifiable", err)
+	}
+}
+
+func TestParseShareHTMLRejectsOversizeAndTooManyMessages(t *testing.T) {
+	if _, err := ParseClaudeHTML(make([]byte, MaxHTMLBytes+1)); !errors.Is(err, ErrLimitExceeded) {
+		t.Fatalf("oversize HTML error = %v", err)
+	}
+
+	messages := make([]Message, MaxMessages+1)
+	for i := range messages {
+		messages[i] = Message{Role: RoleUser, Text: "x"}
+	}
+	if err := validateMessages(messages); !errors.Is(err, ErrLimitExceeded) {
+		t.Fatalf("message limit error = %v", err)
+	}
+}
+
+func TestParseChatGPTHTMLDecodesReactRouterStreamSnapshot(t *testing.T) {
+	flattened := `[
+  {"_1":2},"loaderData",{"_3":4},"routes/share.$shareId.($action)",{"_5":6},"serverResponse",
+  {"_7":8,"_9":10,"_11":12},"title","Streamed plan","current_node","a1","mapping",
+  {"_13":14,"_15":16},"u1",{"_17":-5,"_18":19},"a1",{"_17":13,"_18":20},"parent","message",
+  {"_21":22,"_23":24,"_31":32},{"_21":36,"_23":37,"_31":38},"id","m1","author",{"_27":28},
+  null,null,"role","user",null,null,"content",{"_33":34},"parts",[35],"Question","m2",{"_27":39},
+  {"_33":40},"assistant",[41],"Answer"
+]`
+	quoted, err := json.Marshal(flattened)
+	if err != nil {
+		t.Fatal(err)
+	}
+	html := []byte(`<script nonce="fixture">window.__reactRouterContext.streamController.enqueue(` + string(quoted) + `)</script>`)
+
+	conversation, err := ParseChatGPTHTML(html)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conversation.Title != "Streamed plan" || len(conversation.Messages) != 2 {
+		t.Fatalf("conversation = %#v", conversation)
+	}
+	if conversation.Messages[0].Role != RoleUser || conversation.Messages[0].Text != "Question" ||
+		conversation.Messages[1].Role != RoleAssistant || conversation.Messages[1].Text != "Answer" {
+		t.Fatalf("messages = %#v", conversation.Messages)
+	}
+}

--- a/internal/importer/html_test.go
+++ b/internal/importer/html_test.go
@@ -63,6 +63,29 @@ func TestParseClaudeHTMLReadsExplicitMessageArrayAndSkipsNonTextBlocks(t *testin
 	}
 }
 
+func TestParseClaudeHTMLPreservesTextBlockBoundaries(t *testing.T) {
+	html := []byte(`<script type="application/json">{
+  "chat_messages":[
+    {"uuid":"u1","sender":"human","content":[
+      {"type":"text","text":"Before"},
+      {"type":"attachment","name":"omitted.pdf"},
+      {"type":"text","text":"After"}
+    ]}
+  ]
+}</script>`)
+
+	conversation, err := ParseClaudeHTML(html)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(conversation.Messages) != 1 || conversation.Messages[0].Text != "Before\nAfter" {
+		t.Fatalf("message blocks = %#v, want a visible newline boundary", conversation.Messages)
+	}
+	if len(conversation.Warnings) == 0 {
+		t.Fatal("expected an omitted-content warning")
+	}
+}
+
 func TestParseShareHTMLFailsClosed(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/importer/html_test.go
+++ b/internal/importer/html_test.go
@@ -178,3 +178,25 @@ func TestParseChatGPTHTMLDecodesReactRouterStreamSnapshot(t *testing.T) {
 		t.Fatalf("messages = %#v", conversation.Messages)
 	}
 }
+
+func TestParseChatGPTHTMLDecodesKnownStateAssignment(t *testing.T) {
+	html := []byte(`<script>
+window.__NEXT_DATA__
+window.__INITIAL_STATE__ = {
+  "title":"Assigned state",
+  "current_node":"a1",
+  "mapping":{
+    "u1":{"parent":null,"message":{"id":"u1","author":{"role":"user"},"content":{"parts":["Question"]}}},
+    "a1":{"parent":"u1","message":{"id":"a1","author":{"role":"assistant"},"content":{"parts":["Answer"]}}}
+  }
+};
+</script>`)
+
+	conversation, err := ParseChatGPTHTML(html)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conversation.Title != "Assigned state" || len(conversation.Messages) != 2 || conversation.Messages[1].Text != "Answer" {
+		t.Fatalf("assigned conversation = %#v", conversation)
+	}
+}

--- a/internal/importer/html_test.go
+++ b/internal/importer/html_test.go
@@ -86,6 +86,39 @@ func TestParseClaudeHTMLPreservesTextBlockBoundaries(t *testing.T) {
 	}
 }
 
+func TestParseClaudeHTMLSkipsEntirelyNonTextTurns(t *testing.T) {
+	html := []byte(`<script type="application/json">{
+  "chat_messages":[
+    {"uuid":"u1","sender":"human","content":[{"type":"tool_use","name":"search"}]},
+    {"uuid":"a1","sender":"assistant","content":[{"type":"text","text":"Visible answer"}]}
+  ]
+}</script>`)
+
+	conversation, err := ParseClaudeHTML(html)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(conversation.Messages) != 1 || conversation.Messages[0].Role != RoleAssistant || conversation.Messages[0].Text != "Visible answer" {
+		t.Fatalf("messages = %#v", conversation.Messages)
+	}
+	if len(conversation.Warnings) != 1 || conversation.Warnings[0].Code != "omitted_non_text_content" || conversation.Warnings[0].Count != 1 {
+		t.Fatalf("warnings = %#v", conversation.Warnings)
+	}
+}
+
+func TestParseClaudeHTMLFailsClosedWhenOnlyNonTextTurnsRemain(t *testing.T) {
+	html := []byte(`<script type="application/json">{
+  "chat_messages":[
+    {"uuid":"u1","sender":"human","content":[{"type":"tool_use","name":"search"}]},
+    {"uuid":"a1","sender":"assistant","content":[{"type":"image","source":"omitted"}]}
+  ]
+}</script>`)
+
+	if _, err := ParseClaudeHTML(html); !errors.Is(err, ErrConversationUnidentifiable) {
+		t.Fatalf("error = %v, want ErrConversationUnidentifiable", err)
+	}
+}
+
 func TestParseShareHTMLFailsClosed(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/importer/html_test.go
+++ b/internal/importer/html_test.go
@@ -119,6 +119,78 @@ func TestParseClaudeHTMLFailsClosedWhenOnlyNonTextTurnsRemain(t *testing.T) {
 	}
 }
 
+func TestParseChatGPTHTMLSkipsAttachmentOnlyTurns(t *testing.T) {
+	html := []byte(`<script type="application/json">{
+	  "current_node":"a1",
+	  "mapping":{
+	    "u1":{"parent":null,"message":{"author":{"role":"user"},"content":{"content_type":"multimodal_text","parts":[{"content_type":"image_asset_pointer","asset_pointer":"not-downloaded"}]}}},
+	    "a1":{"parent":"u1","message":{"author":{"role":"assistant"},"content":{"content_type":"text","parts":["Visible answer"]}}}
+	  }
+	}</script>`)
+	conversation, err := ParseChatGPTHTML(html)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(conversation.Messages) != 1 || conversation.Messages[0].Role != RoleAssistant || conversation.Messages[0].Text != "Visible answer" {
+		t.Fatalf("messages = %#v", conversation.Messages)
+	}
+	if len(conversation.Warnings) != 1 || conversation.Warnings[0].Code != "omitted_non_text_content" || conversation.Warnings[0].Count != 1 {
+		t.Fatalf("warnings = %#v", conversation.Warnings)
+	}
+	withoutVisibleText := []byte(`<script type="application/json">{"current_node":"u1","mapping":{"u1":{"parent":null,"message":{"author":{"role":"user"},"content":{"content_type":"multimodal_text","parts":[{"content_type":"image_asset_pointer"}]}}}}}</script>`)
+	if _, err := ParseChatGPTHTML(withoutVisibleText); !errors.Is(err, ErrConversationUnidentifiable) {
+		t.Fatalf("all non-text error = %v, want ErrConversationUnidentifiable", err)
+	}
+}
+
+func TestShareParsersRespectObjectContentTypes(t *testing.T) {
+	for _, contentType := range []string{"thinking", "tool_use", "code", "image"} {
+		t.Run(contentType, func(t *testing.T) {
+			content := map[string]any{"content_type": contentType, "text": "must not become visible conversation"}
+			chatGPT, _ := json.Marshal(map[string]any{
+				"current_node": "a1", "mapping": map[string]any{
+					"hidden": map[string]any{"parent": nil, "message": map[string]any{"author": map[string]any{"role": "assistant"}, "content": content}},
+					"a1":     map[string]any{"parent": "hidden", "message": map[string]any{"author": map[string]any{"role": "assistant"}, "content": map[string]any{"content_type": "text", "parts": []string{"Visible answer"}}}},
+				},
+			})
+			claude, _ := json.Marshal(map[string]any{"chat_messages": []any{
+				map[string]any{"sender": "assistant", "content": map[string]any{"type": contentType, "text": "must not become visible conversation"}},
+				map[string]any{"sender": "assistant", "content": map[string]any{"type": "text", "text": "Visible answer"}},
+			}})
+			for source, data := range map[SourceKind][]byte{SourceChatGPTShare: chatGPT, SourceClaudeShare: claude} {
+				conversation, err := parseShareJSON(data, source)
+				if err != nil {
+					t.Fatalf("%s: %v", source, err)
+				}
+				if len(conversation.Messages) != 1 || conversation.Messages[0].Text != "Visible answer" {
+					t.Fatalf("%s messages = %#v", source, conversation.Messages)
+				}
+				if len(conversation.Warnings) != 1 || conversation.Warnings[0].Code != "omitted_non_text_content" || conversation.Warnings[0].Count != 1 {
+					t.Fatalf("%s warnings = %#v", source, conversation.Warnings)
+				}
+			}
+		})
+	}
+}
+
+func TestShareParsersRejectMalformedTextEvenWithNonTextLosses(t *testing.T) {
+	contents := []string{
+		`[{"type":"image"},{"type":"text","text":"  "}]`,
+		`[{"type":"image"},{"type":"text","text":42}]`,
+		`[{"type":"image"},{"type":"text"}]`,
+		`{"type":"text","text":42}`,
+	}
+	for _, content := range contents {
+		claude := []byte(`{"chat_messages":[{"sender":"human","content":` + content + `},{"sender":"assistant","text":"Visible answer"}]}`)
+		chatGPT := []byte(`{"current_node":"a1","mapping":{"u1":{"parent":null,"message":{"author":{"role":"user"},"content":` + content + `}},"a1":{"parent":"u1","message":{"author":{"role":"assistant"},"content":{"parts":["Visible answer"]}}}}}`)
+		for source, data := range map[SourceKind][]byte{SourceChatGPTShare: chatGPT, SourceClaudeShare: claude} {
+			if _, err := parseShareJSON(data, source); !errors.Is(err, ErrConversationUnidentifiable) {
+				t.Errorf("%s content %s: error = %v, want ErrConversationUnidentifiable", source, content, err)
+			}
+		}
+	}
+}
+
 func TestParseShareHTMLFailsClosed(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/importer/json.go
+++ b/internal/importer/json.go
@@ -6,11 +6,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"unicode/utf8"
 )
 
 func ParseJSON(data []byte) (Conversation, error) {
 	if len(data) > MaxHTMLBytes {
 		return Conversation{}, fmt.Errorf("%w: JSON exceeds %d bytes", ErrLimitExceeded, MaxHTMLBytes)
+	}
+	if !utf8.Valid(data) {
+		return Conversation{}, ErrInvalidUTF8
 	}
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.DisallowUnknownFields()

--- a/internal/importer/json.go
+++ b/internal/importer/json.go
@@ -1,0 +1,48 @@
+package importer
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+func ParseJSON(data []byte) (Conversation, error) {
+	if len(data) > MaxHTMLBytes {
+		return Conversation{}, fmt.Errorf("%w: JSON exceeds %d bytes", ErrLimitExceeded, MaxHTMLBytes)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+
+	var conversation Conversation
+	if err := decoder.Decode(&conversation); err != nil {
+		return Conversation{}, fmt.Errorf("%w: %v", ErrInvalidJSON, err)
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		return Conversation{}, err
+	}
+	for index := range conversation.Messages {
+		conversation.Messages[index].Text = normalizeLineEndings(conversation.Messages[index].Text)
+	}
+	if err := validateConversation(conversation); err != nil {
+		if errors.Is(err, ErrUnsupportedSchema) || errors.Is(err, ErrLimitExceeded) || errors.Is(err, ErrInvalidUTF8) || errors.Is(err, ErrNoConversation) {
+			return conversation, err
+		}
+		return conversation, fmt.Errorf("%w: %v", ErrInvalidJSON, err)
+	}
+	if unassigned := countUnassigned(conversation.Messages); unassigned > 0 {
+		return conversation, &AmbiguityError{UnassignedBlocks: unassigned, Conversation: conversation}
+	}
+	return conversation, nil
+}
+
+func ensureJSONEOF(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); errors.Is(err, io.EOF) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidJSON, err)
+	}
+	return fmt.Errorf("%w: multiple JSON values", ErrInvalidJSON)
+}

--- a/internal/importer/text.go
+++ b/internal/importer/text.go
@@ -1,0 +1,203 @@
+package importer
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+type TextOptions struct {
+	AsOneContextNote bool
+	SourceKind       SourceKind
+	AcquiredAt       time.Time
+	Title            string
+}
+
+type textBlock struct {
+	role Role
+	text string
+}
+
+func ParseText(input string, options TextOptions) (Conversation, error) {
+	if !utf8.ValidString(input) {
+		return Conversation{}, ErrInvalidUTF8
+	}
+	input = normalizeLineEndings(input)
+	if len(input) > MaxTextBytes {
+		return Conversation{}, fmt.Errorf("%w: text exceeds %d bytes", ErrLimitExceeded, MaxTextBytes)
+	}
+	if strings.TrimSpace(input) == "" {
+		return Conversation{}, ErrNoConversation
+	}
+
+	conversation := newTextConversation(options)
+	if !validSourceKind(conversation.SourceKind) {
+		return Conversation{}, fmt.Errorf("unsupported source kind %q", conversation.SourceKind)
+	}
+	if options.AsOneContextNote {
+		conversation.Messages = []Message{{Role: RoleUser, Text: contextNoteText(conversation.SourceKind, input)}}
+		if err := validateConversation(conversation); err != nil {
+			return conversation, err
+		}
+		return conversation, nil
+	}
+
+	blocks := splitExplicitRoleBlocks(input)
+	conversation.Messages = make([]Message, 0, len(blocks))
+	for _, block := range blocks {
+		conversation.Messages = append(conversation.Messages, Message{Role: block.role, Text: block.text})
+	}
+	if err := validateConversation(conversation); err != nil {
+		return conversation, err
+	}
+	if unassigned := countUnassigned(conversation.Messages); unassigned > 0 {
+		return conversation, &AmbiguityError{UnassignedBlocks: unassigned, Conversation: conversation}
+	}
+	return conversation, nil
+}
+
+func contextNoteText(kind SourceKind, input string) string {
+	label := strings.ReplaceAll(string(kind), "_", " ")
+	return "[Imported conversation context from " + label + "]\n\n" + input
+}
+
+func newTextConversation(options TextOptions) Conversation {
+	kind := options.SourceKind
+	if kind == "" {
+		kind = SourcePastedText
+	}
+	acquiredAt := options.AcquiredAt
+	if acquiredAt.IsZero() {
+		acquiredAt = time.Now()
+	}
+	return Conversation{
+		SchemaVersion: SchemaVersion,
+		SourceKind:    kind,
+		AcquiredAt:    acquiredAt.UTC(),
+		Title:         options.Title,
+		Completeness:  CompletenessUnknown,
+	}
+}
+
+func splitExplicitRoleBlocks(input string) []textBlock {
+	var (
+		blocks      []textBlock
+		body        strings.Builder
+		currentRole = RoleUnassigned
+		fence       rune
+		fenceLength int
+	)
+
+	flush := func(beforeRoleHeader bool) {
+		text := body.String()
+		body.Reset()
+		if beforeRoleHeader && strings.HasSuffix(text, "\n") {
+			text = strings.TrimSuffix(text, "\n")
+		}
+		if strings.TrimSpace(text) != "" {
+			blocks = append(blocks, textBlock{role: currentRole, text: text})
+		}
+	}
+
+	for offset := 0; offset < len(input); {
+		end := strings.IndexByte(input[offset:], '\n')
+		hasNewline := end >= 0
+		if hasNewline {
+			end += offset
+		} else {
+			end = len(input)
+		}
+		line := input[offset:end]
+		next := end
+		if hasNewline {
+			next++
+		}
+
+		if marker, length, closing := parseFenceLine(line, fence, fenceLength); marker != 0 {
+			body.WriteString(input[offset:next])
+			if closing {
+				fence, fenceLength = 0, 0
+			} else if fence == 0 {
+				fence, fenceLength = marker, length
+			}
+			offset = next
+			continue
+		}
+
+		if fence == 0 && !isQuotedLine(line) {
+			if role, inline, ok := explicitRoleHeader(line); ok {
+				flush(true)
+				currentRole = role
+				if inline != "" {
+					body.WriteString(inline)
+					if hasNewline {
+						body.WriteByte('\n')
+					}
+				}
+				offset = next
+				continue
+			}
+		}
+
+		body.WriteString(input[offset:next])
+		offset = next
+	}
+	flush(false)
+	return blocks
+}
+
+func explicitRoleHeader(line string) (Role, string, bool) {
+	colon := strings.IndexByte(line, ':')
+	if colon < 0 {
+		return "", "", false
+	}
+	label := line[:colon]
+	var role Role
+	switch {
+	case strings.EqualFold(label, "user"), strings.EqualFold(label, "human"):
+		role = RoleUser
+	case strings.EqualFold(label, "assistant"), strings.EqualFold(label, "chatgpt"), strings.EqualFold(label, "claude"):
+		role = RoleAssistant
+	default:
+		return "", "", false
+	}
+	inline := line[colon+1:]
+	if strings.HasPrefix(inline, " ") {
+		inline = inline[1:]
+	}
+	return role, inline, true
+}
+
+func isQuotedLine(line string) bool {
+	trimmed := strings.TrimLeft(line, " \t")
+	return strings.HasPrefix(trimmed, ">")
+}
+
+func parseFenceLine(line string, open rune, openLength int) (rune, int, bool) {
+	spaces := 0
+	for spaces < len(line) && line[spaces] == ' ' {
+		spaces++
+	}
+	if spaces > 3 || spaces == len(line) {
+		return 0, 0, false
+	}
+	marker := rune(line[spaces])
+	if marker != '`' && marker != '~' {
+		return 0, 0, false
+	}
+	length := 0
+	for spaces+length < len(line) && rune(line[spaces+length]) == marker {
+		length++
+	}
+	if length < 3 {
+		return 0, 0, false
+	}
+	if open == 0 {
+		return marker, length, false
+	}
+	if marker != open || length < openLength || strings.TrimSpace(line[spaces+length:]) != "" {
+		return 0, 0, false
+	}
+	return marker, length, true
+}

--- a/internal/importer/text.go
+++ b/internal/importer/text.go
@@ -162,10 +162,7 @@ func explicitRoleHeader(line string) (Role, string, bool) {
 	default:
 		return "", "", false
 	}
-	inline := line[colon+1:]
-	if strings.HasPrefix(inline, " ") {
-		inline = inline[1:]
-	}
+	inline := strings.TrimPrefix(line[colon+1:], " ")
 	return role, inline, true
 }
 

--- a/internal/importer/url.go
+++ b/internal/importer/url.go
@@ -1,0 +1,94 @@
+package importer
+
+import (
+	"fmt"
+	"net/netip"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+var shareTokenPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{8,160}$`)
+
+var nonPublicPrefixes = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/8"),
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("192.0.0.0/24"),
+	netip.MustParsePrefix("192.0.2.0/24"),
+	netip.MustParsePrefix("198.18.0.0/15"),
+	netip.MustParsePrefix("198.51.100.0/24"),
+	netip.MustParsePrefix("203.0.113.0/24"),
+	netip.MustParsePrefix("2001:db8::/32"),
+}
+
+// ValidateShareURL accepts only public conversation URL shapes that have a
+// dedicated parser. In particular, normal ChatGPT /c and scheduled-task /s
+// URLs are not share pages.
+func ValidateShareURL(rawURL string) (SourceKind, error) {
+	kind, _, err := validateShareURL(rawURL)
+	return kind, err
+}
+
+func validateShareURL(rawURL string) (SourceKind, *url.URL, error) {
+	if rawURL == "" || strings.TrimSpace(rawURL) != rawURL {
+		return "", nil, ErrUnsupportedURL
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil || !parsed.IsAbs() || parsed.Opaque != "" {
+		return "", nil, fmt.Errorf("%w: malformed URL", ErrUnsupportedURL)
+	}
+	if parsed.Scheme != "https" || parsed.User != nil || parsed.Host == "" {
+		return "", nil, fmt.Errorf("%w: HTTPS without user information is required", ErrUnsupportedURL)
+	}
+	if parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
+		return "", nil, fmt.Errorf("%w: query strings and fragments are not accepted", ErrUnsupportedURL)
+	}
+	if parsed.Port() != "" && parsed.Port() != "443" {
+		return "", nil, fmt.Errorf("%w: nonstandard ports are not accepted", ErrUnsupportedURL)
+	}
+	if parsed.RawPath != "" || strings.Contains(parsed.EscapedPath(), "%") {
+		return "", nil, fmt.Errorf("%w: encoded paths are not accepted", ErrUnsupportedURL)
+	}
+
+	host := strings.ToLower(parsed.Hostname())
+	var kind SourceKind
+	switch host {
+	case "chatgpt.com":
+		kind = SourceChatGPTShare
+	case "claude.ai":
+		kind = SourceClaudeShare
+	default:
+		return "", nil, fmt.Errorf("%w: host %q is not allowed", ErrUnsupportedURL, host)
+	}
+	if host != parsed.Hostname() && !strings.EqualFold(host, parsed.Hostname()) {
+		return "", nil, ErrUnsupportedURL
+	}
+
+	const prefix = "/share/"
+	if !strings.HasPrefix(parsed.Path, prefix) {
+		return "", nil, fmt.Errorf("%w: path is not a public conversation share", ErrUnsupportedURL)
+	}
+	token := strings.TrimPrefix(parsed.Path, prefix)
+	if !shareTokenPattern.MatchString(token) {
+		return "", nil, fmt.Errorf("%w: invalid share token", ErrUnsupportedURL)
+	}
+	return kind, parsed, nil
+}
+
+func validatePublicIPs(addresses []netip.Addr) error {
+	if len(addresses) == 0 {
+		return fmt.Errorf("%w: DNS returned no addresses", ErrUnsafeAddress)
+	}
+	for _, address := range addresses {
+		address = address.Unmap()
+		if !address.IsValid() || !address.IsGlobalUnicast() || address.IsPrivate() || address.IsLoopback() || address.IsLinkLocalUnicast() || address.IsLinkLocalMulticast() || address.IsUnspecified() || address.IsMulticast() {
+			return fmt.Errorf("%w: %s", ErrUnsafeAddress, address)
+		}
+		for _, prefix := range nonPublicPrefixes {
+			if prefix.Contains(address) {
+				return fmt.Errorf("%w: %s", ErrUnsafeAddress, address)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/importer/url_test.go
+++ b/internal/importer/url_test.go
@@ -45,6 +45,12 @@ func TestValidateShareURL(t *testing.T) {
 	}
 }
 
+func TestValidateShareURLPublicWrapper(t *testing.T) {
+	if kind, err := ValidateShareURL("https://claude.ai/share/01234567-89ab-cdef-0123-456789abcdef"); err != nil || kind != SourceClaudeShare {
+		t.Fatalf("ValidateShareURL = %q, %v", kind, err)
+	}
+}
+
 func TestRejectNonPublicAddresses(t *testing.T) {
 	blocked := []string{
 		"127.0.0.1", "10.0.0.1", "172.16.0.1", "192.168.1.1",

--- a/internal/importer/url_test.go
+++ b/internal/importer/url_test.go
@@ -1,0 +1,66 @@
+package importer
+
+import (
+	"errors"
+	"net/netip"
+	"testing"
+)
+
+func TestValidateShareURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		kind SourceKind
+		ok   bool
+	}{
+		{"chatgpt", "https://chatgpt.com/share/abcDEF_123-xyz", SourceChatGPTShare, true},
+		{"chatgpt standard port", "https://chatgpt.com:443/share/12345678", SourceChatGPTShare, true},
+		{"claude public", "https://claude.ai/share/01234567-89ab-cdef-0123-456789abcdef", SourceClaudeShare, true},
+		{"http", "http://chatgpt.com/share/12345678", "", false},
+		{"chatgpt private", "https://chatgpt.com/c/12345678", "", false},
+		{"chatgpt scheduled task", "https://chatgpt.com/s/12345678", "", false},
+		{"lookalike", "https://chatgpt.com.example/share/12345678", "", false},
+		{"userinfo", "https://chatgpt.com@evil.example/share/12345678", "", false},
+		{"nonstandard port", "https://chatgpt.com:8443/share/12345678", "", false},
+		{"extra path", "https://chatgpt.com/share/12345678/extra", "", false},
+		{"encoded slash", "https://chatgpt.com/share/12345678%2Fevil", "", false},
+		{"query", "https://chatgpt.com/share/12345678?next=https://evil.example", "", false},
+		{"claude invite", "https://claude.ai/chat/01234567-89ab-cdef-0123-456789abcdef", "", false},
+		{"short token", "https://claude.ai/share/short", "", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			kind, _, err := validateShareURL(test.url)
+			if test.ok {
+				if err != nil || kind != test.kind {
+					t.Fatalf("validateShareURL() = %q, %v; want %q, nil", kind, err, test.kind)
+				}
+				return
+			}
+			if !errors.Is(err, ErrUnsupportedURL) {
+				t.Fatalf("error = %v, want ErrUnsupportedURL", err)
+			}
+		})
+	}
+}
+
+func TestRejectNonPublicAddresses(t *testing.T) {
+	blocked := []string{
+		"127.0.0.1", "10.0.0.1", "172.16.0.1", "192.168.1.1",
+		"169.254.1.1", "100.64.0.1", "0.0.0.0", "::1", "fe80::1", "fc00::1",
+	}
+	for _, raw := range blocked {
+		t.Run(raw, func(t *testing.T) {
+			if err := validatePublicIPs([]netip.Addr{netip.MustParseAddr(raw)}); !errors.Is(err, ErrUnsafeAddress) {
+				t.Fatalf("error = %v, want ErrUnsafeAddress", err)
+			}
+		})
+	}
+	if err := validatePublicIPs([]netip.Addr{netip.MustParseAddr("93.184.216.34")}); err != nil {
+		t.Fatalf("public address rejected: %v", err)
+	}
+	if err := validatePublicIPs([]netip.Addr{netip.MustParseAddr("93.184.216.34"), netip.MustParseAddr("127.0.0.1")}); !errors.Is(err, ErrUnsafeAddress) {
+		t.Fatalf("mixed DNS answer error = %v, want ErrUnsafeAddress", err)
+	}
+}

--- a/internal/importer/warning.go
+++ b/internal/importer/warning.go
@@ -1,0 +1,16 @@
+package importer
+
+import "fmt"
+
+// Summary describes source losses without rendering an untrusted warning code.
+func (warning Warning) Summary() string {
+	count := max(0, warning.Count)
+	switch warning.Code {
+	case "omitted_non_text_content":
+		return fmt.Sprintf("%d non-text content blocks omitted", count)
+	case "omitted_unsupported_roles":
+		return fmt.Sprintf("%d messages with unsupported roles omitted", count)
+	default:
+		return "The source reports an additional import warning"
+	}
+}

--- a/internal/session/import.go
+++ b/internal/session/import.go
@@ -1,0 +1,444 @@
+package session
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+// ImportMode identifies whether imported text becomes a new native session or
+// is added to an existing session's model context.
+type ImportMode string
+
+const (
+	ImportCreate        ImportMode = "create"
+	ImportAppendContext ImportMode = "append-context"
+
+	importPlanVersion = 1
+)
+
+var (
+	ErrImportAppendUnavailable = errors.New("append-context import is unavailable for this provider")
+	ErrImportTargetChanged     = errors.New("import target changed; review the import again")
+	ErrImportVerification      = errors.New("native import verification failed")
+	ErrImportOutcomeUncertain  = errors.New("an earlier import may have completed; inspect the target before retrying")
+)
+
+// ImportMessage is the session package's deliberately small boundary type.
+// Source parsers map their richer message records into this type without
+// coupling native session writers to importer metadata or acquisition logic.
+type ImportMessage struct {
+	Role string `json:"role"`
+	Text string `json:"text"`
+}
+
+// ImportCapability reports the two independently supported target operations.
+// NativeHistoryVisible describes append-context display behavior; Codex keeps
+// injected items in model-visible history but does not expose them as bubbles.
+type ImportCapability struct {
+	CanCreate            bool   `json:"can_create"`
+	CanAppendContext     bool   `json:"can_append_context"`
+	NativeHistoryVisible bool   `json:"native_history_visible"`
+	RequiresCLI          bool   `json:"requires_cli"`
+	Reason               string `json:"reason,omitempty"`
+}
+
+// ImportRevision is the preview-time identity of a native session file. The
+// aggregate Revision is convenient for receipts, while the individual fields
+// make review output and diagnostics explicit.
+type ImportRevision struct {
+	Size     int64     `json:"size"`
+	SHA256   string    `json:"sha256"`
+	ModTime  time.Time `json:"mtime"`
+	Revision string    `json:"revision"`
+}
+
+// ImportRequest is accepted by PlanImport. Create uses Provider+CWD; append
+// uses Target and never substitutes the caller's current working directory.
+// ObservedRevision may carry a revision shown by an earlier preview. When set,
+// planning refuses to silently replace that reviewed target snapshot.
+type ImportRequest struct {
+	Mode             ImportMode      `json:"mode"`
+	Provider         Provider        `json:"provider,omitempty"`
+	CWD              string          `json:"cwd,omitempty"`
+	Target           Row             `json:"target,omitempty"`
+	Messages         []ImportMessage `json:"messages"`
+	ObservedRevision *ImportRevision `json:"observed_revision,omitempty"`
+}
+
+// ImportPlan is a validated preview and immutable content snapshot. Callers
+// can inspect ReviewedMessages; ApplyImport uses a private copy so mutating a
+// parser/request slice after preview cannot change what is written.
+type ImportPlan struct {
+	PlanVersion        int              `json:"plan_version"`
+	OperationID        string           `json:"operation_id"`
+	Mode               ImportMode       `json:"mode"`
+	Provider           Provider         `json:"provider"`
+	CWD                string           `json:"cwd"`
+	Target             Row              `json:"target,omitempty"`
+	ObservedRevision   ImportRevision   `json:"observed_revision,omitempty"`
+	SourceSnapshotHash string           `json:"source_snapshot_hash"`
+	MessageCount       int              `json:"message_count"`
+	Capability         ImportCapability `json:"capability"`
+	ReviewedMessages   []ImportMessage  `json:"reviewed_messages"`
+
+	messages []ImportMessage
+}
+
+// ImportReceipt describes the native target produced or updated by an import.
+type ImportReceipt struct {
+	OperationID          string         `json:"operation_id"`
+	Mode                 ImportMode     `json:"mode"`
+	Provider             Provider       `json:"provider"`
+	Row                  Row            `json:"row"`
+	MessageCount         int            `json:"message_count"`
+	SourceSnapshotHash   string         `json:"source_snapshot_hash"`
+	BeforeRevision       ImportRevision `json:"before_revision,omitempty"`
+	AfterRevision        ImportRevision `json:"after_revision,omitempty"`
+	NativeHistoryVisible bool           `json:"native_history_visible"`
+	NoOp                 bool           `json:"no_op,omitempty"`
+}
+
+// ImportCapabilities returns conservative provider support. Every registered
+// provider already has a native new-session writer. Only Codex currently has a
+// proven no-model-turn append adapter.
+func ImportCapabilities(provider Provider) ImportCapability {
+	if _, ok := providerFor(provider); !ok {
+		return ImportCapability{Reason: fmt.Sprintf("unsupported provider %q", provider)}
+	}
+
+	capability := ImportCapability{CanCreate: true}
+	if provider == ProviderCodex {
+		capability.CanAppendContext = true
+		capability.RequiresCLI = true
+		return capability
+	}
+
+	// OpenCode's create writer also goes through its CLI. The remaining local
+	// writers can create sessions without launching their provider executable.
+	capability.RequiresCLI = provider == ProviderOpenCode
+	capability.Reason = fmt.Sprintf("%s has no verified native append-context API that avoids starting a model turn", DisplayName(provider))
+	return capability
+}
+
+// PlanImport validates roles, text, target ownership, and folder selection,
+// then captures the exact content and (for append) native file revision that
+// ApplyImport must see again.
+func PlanImport(request ImportRequest) (ImportPlan, error) {
+	messages, err := validateImportMessages(request.Messages)
+	if err != nil {
+		return ImportPlan{}, err
+	}
+
+	operationID, err := newUUID()
+	if err != nil {
+		return ImportPlan{}, fmt.Errorf("allocate import operation: %w", err)
+	}
+	plan := ImportPlan{
+		PlanVersion:        importPlanVersion,
+		OperationID:        operationID,
+		Mode:               request.Mode,
+		SourceSnapshotHash: importMessagesHash(messages),
+		MessageCount:       len(messages),
+		ReviewedMessages:   cloneImportMessages(messages),
+		messages:           cloneImportMessages(messages),
+	}
+
+	switch request.Mode {
+	case ImportCreate:
+		capability := ImportCapabilities(request.Provider)
+		if !capability.CanCreate {
+			return ImportPlan{}, fmt.Errorf("cannot create import target: %s", capability.Reason)
+		}
+		cwd, err := resolveImportWorkspace(request.CWD)
+		if err != nil {
+			return ImportPlan{}, err
+		}
+		plan.Provider = request.Provider
+		plan.CWD = cwd
+		plan.Capability = capability
+	case ImportAppendContext:
+		capability := ImportCapabilities(request.Target.Provider)
+		if !capability.CanAppendContext {
+			return ImportPlan{}, fmt.Errorf("%w: %s", ErrImportAppendUnavailable, capability.Reason)
+		}
+		target, revision, err := validateAppendTarget(request.Target)
+		if err != nil {
+			return ImportPlan{}, err
+		}
+		if request.ObservedRevision != nil && !sameImportRevision(*request.ObservedRevision, revision) {
+			return ImportPlan{}, ErrImportTargetChanged
+		}
+		plan.Provider = target.Provider
+		plan.CWD = target.CWD
+		plan.Target = target
+		plan.ObservedRevision = revision
+		plan.Capability = capability
+	default:
+		return ImportPlan{}, fmt.Errorf("unsupported import mode %q", request.Mode)
+	}
+
+	return plan, nil
+}
+
+// ApplyImport applies only a plan produced by PlanImport. New sessions use the
+// existing provider writer behind a source-free API; append is delegated to a
+// provider-specific native adapter.
+func ApplyImport(ctx context.Context, plan ImportPlan) (ImportReceipt, error) {
+	if plan.PlanVersion != importPlanVersion || plan.OperationID == "" || len(plan.messages) == 0 {
+		return ImportReceipt{}, errors.New("invalid import plan; preview the import again")
+	}
+	prior, receiptPath, err := prepareImportReceipt(plan)
+	if err != nil {
+		return ImportReceipt{}, err
+	}
+	if prior != nil {
+		return verifiedCommittedImport(plan, *prior)
+	}
+
+	receipt, err := applyImportNative(ctx, plan)
+	if err != nil {
+		if errors.Is(err, ErrImportTargetChanged) || errors.Is(err, ErrImportAppendUnavailable) {
+			_ = os.Remove(receiptPath)
+		}
+		return ImportReceipt{}, err
+	}
+	if err := commitImportReceipt(receiptPath, receipt); err != nil {
+		return ImportReceipt{}, fmt.Errorf("native import completed but its receipt could not be committed; %w: %v", ErrImportOutcomeUncertain, err)
+	}
+	return receipt, nil
+}
+
+func applyImportNative(ctx context.Context, plan ImportPlan) (ImportReceipt, error) {
+	switch plan.Mode {
+	case ImportCreate:
+		impl, ok := providerFor(plan.Provider)
+		if !ok {
+			return ImportReceipt{}, fmt.Errorf("unsupported target provider %q", plan.Provider)
+		}
+		turns := importTurns(plan.messages)
+		row, err := impl.WriteConverted(Row{CWD: plan.CWD, LaunchCWD: plan.CWD}, turns)
+		if err != nil {
+			return ImportReceipt{}, fmt.Errorf("create %s session from import: %w", DisplayName(plan.Provider), err)
+		}
+		receipt := importReceiptForPlan(plan, row)
+		if row.File != "" {
+			if revision, err := observeImportRevision(row.File); err == nil {
+				receipt.AfterRevision = revision
+			}
+		}
+		return receipt, nil
+	case ImportAppendContext:
+		if plan.Provider != ProviderCodex {
+			return ImportReceipt{}, ErrImportAppendUnavailable
+		}
+		return applyCodexContextImport(ctx, plan)
+	default:
+		return ImportReceipt{}, fmt.Errorf("unsupported import mode %q", plan.Mode)
+	}
+}
+
+func importReceiptForPlan(plan ImportPlan, row Row) ImportReceipt {
+	return ImportReceipt{
+		OperationID:          plan.OperationID,
+		Mode:                 plan.Mode,
+		Provider:             plan.Provider,
+		Row:                  row,
+		MessageCount:         plan.MessageCount,
+		SourceSnapshotHash:   plan.SourceSnapshotHash,
+		BeforeRevision:       plan.ObservedRevision,
+		NativeHistoryVisible: plan.Capability.NativeHistoryVisible,
+	}
+}
+
+func validateImportMessages(input []ImportMessage) ([]ImportMessage, error) {
+	if len(input) == 0 {
+		return nil, errors.New("import has no user or assistant messages")
+	}
+	messages := make([]ImportMessage, len(input))
+	for index, message := range input {
+		if message.Role != "user" && message.Role != "assistant" {
+			return nil, fmt.Errorf("import message %d has unsupported role %q; review roles as user or assistant", index+1, message.Role)
+		}
+		if !utf8.ValidString(message.Text) {
+			return nil, fmt.Errorf("import message %d is not valid UTF-8", index+1)
+		}
+		if strings.TrimSpace(message.Text) == "" {
+			return nil, fmt.Errorf("import message %d has empty text", index+1)
+		}
+		message.Text = normalizeImportNewlines(message.Text)
+		messages[index] = message
+	}
+	return messages, nil
+}
+
+func normalizeImportNewlines(value string) string {
+	value = strings.ReplaceAll(value, "\r\n", "\n")
+	return strings.ReplaceAll(value, "\r", "\n")
+}
+
+func cloneImportMessages(messages []ImportMessage) []ImportMessage {
+	return slices.Clone(messages)
+}
+
+func importTurns(messages []ImportMessage) []Turn {
+	turns := make([]Turn, len(messages))
+	for index, message := range messages {
+		turns[index] = Turn{Role: message.Role, Text: message.Text}
+	}
+	return turns
+}
+
+func importMessagesHash(messages []ImportMessage) string {
+	data, _ := json.Marshal(struct {
+		Version  int             `json:"version"`
+		Messages []ImportMessage `json:"messages"`
+	}{Version: 1, Messages: messages})
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func resolveImportWorkspace(cwd string) (string, error) {
+	if strings.TrimSpace(cwd) == "" {
+		return "", errors.New("import workspace is required")
+	}
+	if !filepath.IsAbs(cwd) {
+		return "", fmt.Errorf("import workspace must be an absolute path: %s", cwd)
+	}
+	resolved, err := filepath.EvalSymlinks(filepath.Clean(cwd))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("import workspace not found: %s", cwd)
+		}
+		return "", fmt.Errorf("import workspace unavailable: %s: %w", cwd, err)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", fmt.Errorf("import workspace unavailable: %s: %w", cwd, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("import workspace is not a directory: %s", cwd)
+	}
+	return filepath.Clean(resolved), nil
+}
+
+func validateAppendTarget(row Row) (Row, ImportRevision, error) {
+	if row.Provider != ProviderCodex || row.HandoffOnly {
+		return Row{}, ImportRevision{}, fmt.Errorf("%w: target must be an exact native Codex session", ErrImportAppendUnavailable)
+	}
+	if strings.TrimSpace(row.ID) == "" {
+		return Row{}, ImportRevision{}, errors.New("append target requires an exact session id")
+	}
+	cwd, err := resolveImportWorkspace(row.CWD)
+	if err != nil {
+		return Row{}, ImportRevision{}, err
+	}
+	if !filepath.IsAbs(row.File) || strings.TrimSpace(row.File) == "" {
+		return Row{}, ImportRevision{}, errors.New("append target requires an absolute native session file")
+	}
+	file, err := filepath.EvalSymlinks(filepath.Clean(row.File))
+	if err != nil {
+		return Row{}, ImportRevision{}, fmt.Errorf("append target session file unavailable: %w", err)
+	}
+	if !pathWithin(filepath.Join(defaultCodexHome(), "sessions"), file) {
+		return Row{}, ImportRevision{}, errors.New("append target is not in the native Codex sessions store")
+	}
+	if err := validateCodexSessionID(file, row.ID); err != nil {
+		return Row{}, ImportRevision{}, err
+	}
+	revision, err := observeImportRevision(file)
+	if err != nil {
+		return Row{}, ImportRevision{}, err
+	}
+	row.CWD = cwd
+	row.LaunchCWD = cwd
+	row.File = file
+	return row, revision, nil
+}
+
+func validateCodexSessionID(path, want string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open append target: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 64*1024), scanBufferMax)
+	for scanner.Scan() {
+		var record codexLine
+		if json.Unmarshal(scanner.Bytes(), &record) != nil || record.Type != "session_meta" {
+			continue
+		}
+		var meta codexSessionMeta
+		if err := json.Unmarshal(record.Payload, &meta); err != nil || meta.ID == "" {
+			return errors.New("append target has invalid Codex session metadata")
+		}
+		if meta.ID != want {
+			return fmt.Errorf("append target id %q does not match native session id %q", want, meta.ID)
+		}
+		return nil
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scan append target: %w", err)
+	}
+	return errors.New("append target has no Codex session metadata")
+}
+
+func observeImportRevision(path string) (ImportRevision, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return ImportRevision{}, fmt.Errorf("open import target revision: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
+	if err != nil {
+		return ImportRevision{}, fmt.Errorf("stat import target revision: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return ImportRevision{}, errors.New("import target is not a regular file")
+	}
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return ImportRevision{}, fmt.Errorf("hash import target revision: %w", err)
+	}
+	digest := hex.EncodeToString(hash.Sum(nil))
+	mtime := info.ModTime().UTC()
+	return ImportRevision{
+		Size:     info.Size(),
+		SHA256:   digest,
+		ModTime:  mtime,
+		Revision: fmt.Sprintf("%d:%d:%s", info.Size(), mtime.UnixNano(), digest),
+	}, nil
+}
+
+func sameImportRevision(left, right ImportRevision) bool {
+	return left.Size == right.Size && left.SHA256 == right.SHA256 && left.ModTime.Equal(right.ModTime) && left.Revision == right.Revision
+}
+
+func pathWithin(root, candidate string) bool {
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+	candidate, err = filepath.Abs(candidate)
+	if err != nil {
+		return false
+	}
+	relative, err := filepath.Rel(root, candidate)
+	if err != nil {
+		return false
+	}
+	return relative != ".." && relative != "." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) && !filepath.IsAbs(relative)
+}

--- a/internal/session/import.go
+++ b/internal/session/import.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -190,7 +191,43 @@ func PlanImport(request ImportRequest) (ImportPlan, error) {
 		return ImportPlan{}, fmt.Errorf("unsupported import mode %q", request.Mode)
 	}
 
+	if err := validateImportNativeRecordSizes(plan.Provider, plan.CWD, plan.messages); err != nil {
+		return ImportPlan{}, err
+	}
 	return plan, nil
+}
+
+// Native JSONL readers bound a whole serialized record, rather than its raw
+// text. Quotes, backslashes and controls can substantially expand during JSON
+// encoding. Reserve space for provider metadata as well as Claude's workspace
+// field so an accepted message remains readable after it has been written.
+func validateImportNativeRecordSizes(provider Provider, cwd string, messages []ImportMessage) error {
+	switch provider {
+	case ProviderCodex, ProviderClaude, ProviderPi, ProviderGemini:
+	default:
+		return nil
+	}
+	const metadataReserve = 4096
+	var encoded bytes.Buffer
+	encoder := json.NewEncoder(&encoded)
+	encoder.SetEscapeHTML(false)
+	_ = encoder.Encode(cwd)
+	reserved := metadataReserve + encoded.Len()
+	conversationSize := reserved
+	for index, message := range messages {
+		encoded.Reset()
+		_ = encoder.Encode(message.Text)
+		if encoded.Len()+reserved >= scanBufferMax {
+			return fmt.Errorf("import message %d exceeds %s's %d MiB native record limit after JSON escaping; split the message before importing", index+1, DisplayName(provider), scanBufferMax/(1024*1024))
+		}
+		// Gemini's legacy writer puts the entire conversation on one line.
+		// Account for each message's UUID, timestamp and field names too.
+		conversationSize += encoded.Len() + 512
+		if provider == ProviderGemini && conversationSize >= scanBufferMax {
+			return fmt.Errorf("import conversation exceeds %s's %d MiB native record limit after JSON escaping; import fewer messages", DisplayName(provider), scanBufferMax/(1024*1024))
+		}
+	}
+	return nil
 }
 
 // ApplyImport applies only a plan produced by PlanImport. New sessions use the
@@ -241,6 +278,12 @@ func applyImportNative(ctx context.Context, plan ImportPlan) (ImportReceipt, err
 		turns := importTurns(plan.messages)
 		row, err := impl.WriteConverted(Row{CWD: plan.CWD, LaunchCWD: plan.CWD}, turns)
 		if err != nil {
+			// The local file writers only report failure before their atomic
+			// rename commits a native session. OpenCode delegates to an external
+			// CLI, whose failure may follow a successful database write.
+			if plan.Provider != ProviderOpenCode {
+				err = fmt.Errorf("%w: %w", errImportNotStarted, err)
+			}
 			return ImportReceipt{}, fmt.Errorf("create %s session from import: %w", DisplayName(plan.Provider), err)
 		}
 		receipt := importReceiptForPlan(plan, row)
@@ -362,7 +405,11 @@ func validateAppendTarget(row Row) (Row, ImportRevision, error) {
 	if err != nil {
 		return Row{}, ImportRevision{}, fmt.Errorf("append target session file unavailable: %w", err)
 	}
-	if !pathWithin(filepath.Join(defaultCodexHome(), "sessions"), file) {
+	store, err := filepath.EvalSymlinks(filepath.Join(defaultCodexHome(), "sessions"))
+	if err != nil {
+		return Row{}, ImportRevision{}, fmt.Errorf("native Codex sessions store unavailable: %w", err)
+	}
+	if !pathWithin(store, file) {
 		return Row{}, ImportRevision{}, errors.New("append target is not in the native Codex sessions store")
 	}
 	if err := validateCodexSessionID(file, row.ID); err != nil {

--- a/internal/session/import.go
+++ b/internal/session/import.go
@@ -199,6 +199,12 @@ func ApplyImport(ctx context.Context, plan ImportPlan) (ImportReceipt, error) {
 	if plan.PlanVersion != importPlanVersion || plan.OperationID == "" || len(plan.messages) == 0 {
 		return ImportReceipt{}, errors.New("invalid import plan; preview the import again")
 	}
+	// Check executable availability before persisting intent. OpenCode create
+	// and Codex append have not touched native state at this point, so a missing
+	// CLI is safely retryable after installation rather than outcome-uncertain.
+	if importNeedsProviderCommand(plan) && !ProviderCommandAvailable(plan.Provider) {
+		return ImportReceipt{}, fmt.Errorf("%s not found in PATH; install it and retry", providerCommand(plan.Provider))
+	}
 	prior, receiptPath, err := prepareImportReceipt(plan)
 	if err != nil {
 		return ImportReceipt{}, err
@@ -218,6 +224,10 @@ func ApplyImport(ctx context.Context, plan ImportPlan) (ImportReceipt, error) {
 		return ImportReceipt{}, fmt.Errorf("native import completed but its receipt could not be committed; %w: %v", ErrImportOutcomeUncertain, err)
 	}
 	return receipt, nil
+}
+
+func importNeedsProviderCommand(plan ImportPlan) bool {
+	return plan.Mode == ImportAppendContext || plan.Mode == ImportCreate && plan.Provider == ProviderOpenCode
 }
 
 func applyImportNative(ctx context.Context, plan ImportPlan) (ImportReceipt, error) {

--- a/internal/session/import.go
+++ b/internal/session/import.go
@@ -33,6 +33,7 @@ var (
 	ErrImportTargetChanged     = errors.New("import target changed; review the import again")
 	ErrImportVerification      = errors.New("native import verification failed")
 	ErrImportOutcomeUncertain  = errors.New("an earlier import may have completed; inspect the target before retrying")
+	errImportNotStarted        = errors.New("native import did not start")
 )
 
 // ImportMessage is the session package's deliberately small boundary type.
@@ -215,7 +216,7 @@ func ApplyImport(ctx context.Context, plan ImportPlan) (ImportReceipt, error) {
 
 	receipt, err := applyImportNative(ctx, plan)
 	if err != nil {
-		if errors.Is(err, ErrImportTargetChanged) || errors.Is(err, ErrImportAppendUnavailable) {
+		if errors.Is(err, ErrImportTargetChanged) || errors.Is(err, ErrImportAppendUnavailable) || errors.Is(err, errImportNotStarted) {
 			_ = os.Remove(receiptPath)
 		}
 		return ImportReceipt{}, err
@@ -227,7 +228,7 @@ func ApplyImport(ctx context.Context, plan ImportPlan) (ImportReceipt, error) {
 }
 
 func importNeedsProviderCommand(plan ImportPlan) bool {
-	return plan.Mode == ImportAppendContext || plan.Mode == ImportCreate && plan.Provider == ProviderOpenCode
+	return plan.Mode == ImportCreate && plan.Provider == ProviderOpenCode
 }
 
 func applyImportNative(ctx context.Context, plan ImportPlan) (ImportReceipt, error) {

--- a/internal/session/import.go
+++ b/internal/session/import.go
@@ -295,7 +295,7 @@ func cloneImportMessages(messages []ImportMessage) []ImportMessage {
 func importTurns(messages []ImportMessage) []Turn {
 	turns := make([]Turn, len(messages))
 	for index, message := range messages {
-		turns[index] = Turn{Role: message.Role, Text: message.Text}
+		turns[index] = Turn(message)
 	}
 	return turns
 }

--- a/internal/session/import_codex.go
+++ b/internal/session/import_codex.go
@@ -1,0 +1,530 @@
+package session
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	importApplyTimeout = 30 * time.Second
+	importRPCTimeout   = 10 * time.Second
+	importCloseTimeout = 2 * time.Second
+	importErrorMax     = 4 * 1024
+)
+
+// codexAppServerCommand is a process seam for tests. Production always uses
+// Codex's native stdio app-server and passes conversation text only as JSON on
+// stdin, never as shell arguments.
+var codexAppServerCommand = func(ctx context.Context, cwd string) *exec.Cmd {
+	command := exec.CommandContext(ctx, "codex", "app-server", "--stdio")
+	command.Dir = cwd
+	return command
+}
+
+var codexImportPathLocks = codexPathLockTable{locks: make(map[string]*codexPathLock)}
+
+type codexPathLockTable struct {
+	mu    sync.Mutex
+	locks map[string]*codexPathLock
+}
+
+type codexPathLock struct {
+	mu   sync.Mutex
+	refs int
+}
+
+// codexImportPathLock prevents two showagent imports in this process from
+// racing on one rollout. It is advisory: a separate Codex/Desktop/showagent
+// process can still write concurrently. Prefix and persisted-item checks catch
+// destructive overlap, but the native protocol currently offers no cross-
+// process lock that showagent can enforce.
+func acquireCodexImportPathLock(path string) func() {
+	key := filepath.Clean(path)
+	codexImportPathLocks.mu.Lock()
+	lock := codexImportPathLocks.locks[key]
+	if lock == nil {
+		lock = &codexPathLock{}
+		codexImportPathLocks.locks[key] = lock
+	}
+	lock.refs++
+	codexImportPathLocks.mu.Unlock()
+
+	lock.mu.Lock()
+	return func() {
+		lock.mu.Unlock()
+		codexImportPathLocks.mu.Lock()
+		lock.refs--
+		if lock.refs == 0 {
+			delete(codexImportPathLocks.locks, key)
+		}
+		codexImportPathLocks.mu.Unlock()
+	}
+}
+
+func applyCodexContextImport(parent context.Context, plan ImportPlan) (ImportReceipt, error) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := importContext(parent)
+	defer cancel()
+
+	releasePathLock := acquireCodexImportPathLock(plan.Target.File)
+	defer releasePathLock()
+
+	before, err := observeImportRevision(plan.Target.File)
+	if err != nil {
+		return ImportReceipt{}, err
+	}
+	if !sameImportRevision(plan.ObservedRevision, before) {
+		return ImportReceipt{}, ErrImportTargetChanged
+	}
+
+	client, err := startCodexImportClient(ctx, plan.Target.CWD)
+	if err != nil {
+		return ImportReceipt{}, err
+	}
+	defer client.close()
+
+	if err := client.call(ctx, "initialize", map[string]any{
+		"clientInfo":   map[string]string{"name": "showagent-import", "version": "1"},
+		"capabilities": map[string]bool{"experimentalApi": true},
+	}, nil); err != nil {
+		return ImportReceipt{}, err
+	}
+	if err := client.notify("initialized"); err != nil {
+		return ImportReceipt{}, err
+	}
+
+	var read codexImportThreadResult
+	if err := client.call(ctx, "thread/read", map[string]any{
+		"threadId": plan.Target.ID, "includeTurns": false,
+	}, &read); err != nil {
+		return ImportReceipt{}, err
+	}
+	if err := verifyCodexRPCThread(plan.Target, read.Thread); err != nil {
+		return ImportReceipt{}, err
+	}
+
+	var resumed codexImportThreadResult
+	if err := client.call(ctx, "thread/resume", map[string]any{
+		"threadId": plan.Target.ID,
+		"cwd":      plan.Target.CWD,
+	}, &resumed); err != nil {
+		return ImportReceipt{}, err
+	}
+	if err := verifyCodexRPCThread(plan.Target, resumed.Thread); err != nil {
+		return ImportReceipt{}, err
+	}
+
+	items := codexImportItems(plan.messages)
+	if err := client.call(ctx, "thread/inject_items", map[string]any{
+		"threadId": plan.Target.ID,
+		"items":    items,
+	}, nil); err != nil {
+		// Once resume succeeds, unsubscribe is attempted even when injection
+		// returns a protocol error. There is no blind retry or raw-file fallback.
+		_ = client.call(ctx, "thread/unsubscribe", map[string]string{"threadId": plan.Target.ID}, nil)
+		return ImportReceipt{}, err
+	}
+	if err := client.call(ctx, "thread/unsubscribe", map[string]string{"threadId": plan.Target.ID}, nil); err != nil {
+		return ImportReceipt{}, err
+	}
+	client.close()
+
+	after, err := verifyCodexImportPersistence(plan.Target.File, before, plan.messages)
+	if err != nil {
+		return ImportReceipt{}, err
+	}
+	receipt := importReceiptForPlan(plan, plan.Target)
+	receipt.BeforeRevision = before
+	receipt.AfterRevision = after
+	return receipt, nil
+}
+
+func importContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if _, hasDeadline := parent.Deadline(); hasDeadline {
+		return context.WithCancel(parent)
+	}
+	return context.WithTimeout(parent, importApplyTimeout)
+}
+
+type codexImportThreadResult struct {
+	Thread struct {
+		ID   string `json:"id"`
+		Path string `json:"path"`
+		CWD  string `json:"cwd"`
+	} `json:"thread"`
+}
+
+func verifyCodexRPCThread(target Row, thread struct {
+	ID   string `json:"id"`
+	Path string `json:"path"`
+	CWD  string `json:"cwd"`
+}) error {
+	if thread.ID != target.ID {
+		return fmt.Errorf("Codex app-server returned thread %q, want exact target %q", thread.ID, target.ID)
+	}
+	if !sameImportPath(thread.Path, target.File) {
+		return fmt.Errorf("Codex app-server returned a different native session file: %s", boundedImportText(thread.Path))
+	}
+	if !sameImportPath(thread.CWD, target.CWD) {
+		return fmt.Errorf("Codex app-server returned a different workspace: %s", boundedImportText(thread.CWD))
+	}
+	return nil
+}
+
+func codexImportItems(messages []ImportMessage) []map[string]any {
+	items := make([]map[string]any, len(messages))
+	for index, message := range messages {
+		contentType := "output_text"
+		if message.Role == "user" {
+			contentType = "input_text"
+		}
+		items[index] = map[string]any{
+			"type": "message",
+			"role": message.Role,
+			"content": []map[string]string{{
+				"type": contentType,
+				"text": message.Text,
+			}},
+		}
+	}
+	return items
+}
+
+func verifyCodexImportPersistence(path string, before ImportRevision, messages []ImportMessage) (ImportRevision, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return ImportRevision{}, fmt.Errorf("%w: reopen Codex session: %v", ErrImportVerification, err)
+	}
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
+	if err != nil {
+		return ImportRevision{}, fmt.Errorf("%w: stat Codex session: %v", ErrImportVerification, err)
+	}
+	if info.Size() < before.Size {
+		return ImportRevision{}, fmt.Errorf("%w: native session became shorter", ErrImportVerification)
+	}
+
+	prefixHash := sha256.New()
+	fullHash := sha256.New()
+	written, err := io.CopyN(io.MultiWriter(prefixHash, fullHash), file, before.Size)
+	if err != nil || written != before.Size {
+		return ImportRevision{}, fmt.Errorf("%w: read original native prefix", ErrImportVerification)
+	}
+	if hex.EncodeToString(prefixHash.Sum(nil)) != before.SHA256 {
+		return ImportRevision{}, fmt.Errorf("%w: original native bytes are not an exact prefix", ErrImportVerification)
+	}
+
+	remaining := make(map[importMessageKey]int, len(messages))
+	for _, message := range messages {
+		remaining[importMessageKey{Role: message.Role, Text: message.Text}]++
+	}
+	scanner := bufio.NewScanner(io.TeeReader(file, fullHash))
+	scanner.Buffer(make([]byte, 64*1024), scanBufferMax)
+	for scanner.Scan() {
+		var record codexLine
+		if json.Unmarshal(scanner.Bytes(), &record) != nil || record.Type != "response_item" {
+			continue
+		}
+		var payload codexMessagePayload
+		if json.Unmarshal(record.Payload, &payload) != nil || payload.Type != "message" {
+			continue
+		}
+		key := importMessageKey{Role: payload.Role, Text: textFromContent(payload.Content)}
+		if remaining[key] > 0 {
+			remaining[key]--
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return ImportRevision{}, fmt.Errorf("%w: scan appended native records: %v", ErrImportVerification, err)
+	}
+	for message, count := range remaining {
+		if count > 0 {
+			return ImportRevision{}, fmt.Errorf("%w: %d %s message(s) missing after original prefix (text sha256 %s)",
+				ErrImportVerification, count, message.Role, shortImportTextHash(message.Text))
+		}
+	}
+	readSize, err := file.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return ImportRevision{}, fmt.Errorf("%w: locate verified Codex session end: %v", ErrImportVerification, err)
+	}
+	afterInfo, err := file.Stat()
+	if err != nil {
+		return ImportRevision{}, fmt.Errorf("%w: restat Codex session: %v", ErrImportVerification, err)
+	}
+	if readSize != afterInfo.Size() {
+		return ImportRevision{}, fmt.Errorf("%w: native session changed while it was being verified", ErrImportVerification)
+	}
+	digest := hex.EncodeToString(fullHash.Sum(nil))
+	mtime := afterInfo.ModTime().UTC()
+	return ImportRevision{
+		Size:     readSize,
+		SHA256:   digest,
+		ModTime:  mtime,
+		Revision: fmt.Sprintf("%d:%d:%s", readSize, mtime.UnixNano(), digest),
+	}, nil
+}
+
+type importMessageKey struct {
+	Role string
+	Text string
+}
+
+func shortImportTextHash(text string) string {
+	sum := sha256.Sum256([]byte(text))
+	return hex.EncodeToString(sum[:8])
+}
+
+func sameImportPath(left, right string) bool {
+	left = normalizeImportPath(left)
+	right = normalizeImportPath(right)
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(left, right)
+	}
+	return left == right
+}
+
+func normalizeImportPath(path string) string {
+	path = strings.TrimSpace(path)
+	if runtime.GOOS == "windows" {
+		path = strings.TrimPrefix(path, `\\?\`)
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+	if absolute, err := filepath.Abs(path); err == nil {
+		path = absolute
+	}
+	return filepath.Clean(path)
+}
+
+type codexImportRPCClient struct {
+	command   *exec.Cmd
+	stdin     io.WriteCloser
+	responses chan codexImportRPCRead
+	done      chan struct{}
+	stderr    *boundedImportBuffer
+
+	mu        sync.Mutex
+	waitErr   error
+	nextID    int64
+	closeOnce sync.Once
+}
+
+type codexImportRPCRead struct {
+	response codexImportRPCResponse
+	err      error
+}
+
+type codexImportRPCResponse struct {
+	ID     json.RawMessage      `json:"id"`
+	Result json.RawMessage      `json:"result"`
+	Error  *codexImportRPCError `json:"error"`
+}
+
+type codexImportRPCError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data"`
+}
+
+func startCodexImportClient(ctx context.Context, cwd string) (*codexImportRPCClient, error) {
+	command := codexAppServerCommand(ctx, cwd)
+	stdin, err := command.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("start Codex app-server stdin: %w", err)
+	}
+	stdout, err := command.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		return nil, fmt.Errorf("start Codex app-server stdout: %w", err)
+	}
+	stderr := &boundedImportBuffer{limit: importErrorMax}
+	command.Stderr = stderr
+	if err := command.Start(); err != nil {
+		_ = stdin.Close()
+		return nil, fmt.Errorf("start `codex app-server --stdio`: %w", err)
+	}
+
+	client := &codexImportRPCClient{
+		command: command, stdin: stdin, responses: make(chan codexImportRPCRead, 64),
+		done: make(chan struct{}), stderr: stderr,
+	}
+	go client.read(stdout)
+	go func() {
+		err := command.Wait()
+		client.mu.Lock()
+		client.waitErr = err
+		client.mu.Unlock()
+		close(client.done)
+	}()
+	return client, nil
+}
+
+func (client *codexImportRPCClient) read(stdout io.Reader) {
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 64*1024), scanBufferMax)
+	for scanner.Scan() {
+		var response codexImportRPCResponse
+		if err := json.Unmarshal(scanner.Bytes(), &response); err != nil {
+			client.responses <- codexImportRPCRead{err: fmt.Errorf("decode Codex app-server response: %w", err)}
+			return
+		}
+		client.responses <- codexImportRPCRead{response: response}
+	}
+	if err := scanner.Err(); err != nil {
+		client.responses <- codexImportRPCRead{err: fmt.Errorf("read Codex app-server response: %w", err)}
+	}
+}
+
+func (client *codexImportRPCClient) call(ctx context.Context, method string, params, result any) error {
+	client.nextID++
+	id := client.nextID
+	request := map[string]any{"id": id, "method": method, "params": params}
+	data, err := json.Marshal(request)
+	if err != nil {
+		return fmt.Errorf("encode Codex app-server %s request: %w", method, err)
+	}
+	data = append(data, '\n')
+	if _, err := client.stdin.Write(data); err != nil {
+		return client.processError(fmt.Sprintf("write Codex app-server %s request", method), err)
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, importRPCTimeout)
+	defer cancel()
+	for {
+		select {
+		case <-callCtx.Done():
+			return fmt.Errorf("Codex app-server %s timed out: %w", method, callCtx.Err())
+		case <-client.done:
+			return client.processError(fmt.Sprintf("Codex app-server exited during %s", method), nil)
+		case read := <-client.responses:
+			if read.err != nil {
+				return client.processError(fmt.Sprintf("Codex app-server failed during %s", method), read.err)
+			}
+			if !rpcResponseIDEquals(read.response.ID, id) {
+				// Notifications and server-initiated messages are unrelated to the
+				// one sequential import request currently in flight.
+				continue
+			}
+			if read.response.Error != nil {
+				message := boundedImportText(read.response.Error.Message)
+				if len(read.response.Error.Data) > 0 && string(read.response.Error.Data) != "null" {
+					message += ": " + boundedImportText(string(read.response.Error.Data))
+				}
+				return fmt.Errorf("Codex app-server %s error %d: %s", method, read.response.Error.Code, message)
+			}
+			if result != nil && len(read.response.Result) > 0 && string(read.response.Result) != "null" {
+				if err := json.Unmarshal(read.response.Result, result); err != nil {
+					return fmt.Errorf("decode Codex app-server %s result: %w", method, err)
+				}
+			}
+			return nil
+		}
+	}
+}
+
+func (client *codexImportRPCClient) notify(method string) error {
+	data, err := json.Marshal(map[string]any{"method": method})
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if _, err := client.stdin.Write(data); err != nil {
+		return client.processError(fmt.Sprintf("write Codex app-server %s notification", method), err)
+	}
+	return nil
+}
+
+func (client *codexImportRPCClient) closeClient() {
+	client.closeOnce.Do(func() {
+		_ = client.stdin.Close()
+		select {
+		case <-client.done:
+			return
+		case <-time.After(importCloseTimeout):
+			if client.command.Process != nil {
+				_ = client.command.Process.Kill()
+			}
+			select {
+			case <-client.done:
+			case <-time.After(importCloseTimeout):
+			}
+		}
+	})
+}
+
+// close is kept as a method name used at call sites while the sync.Once field
+// remains private implementation state.
+func (client *codexImportRPCClient) close() {
+	client.closeClient()
+}
+
+func (client *codexImportRPCClient) processError(prefix string, cause error) error {
+	client.mu.Lock()
+	waitErr := client.waitErr
+	client.mu.Unlock()
+	parts := []string{prefix}
+	if cause != nil {
+		parts = append(parts, cause.Error())
+	}
+	if waitErr != nil {
+		parts = append(parts, waitErr.Error())
+	}
+	if stderr := strings.TrimSpace(client.stderr.String()); stderr != "" {
+		parts = append(parts, stderr)
+	}
+	return errors.New(boundedImportText(strings.Join(parts, ": ")))
+}
+
+func rpcResponseIDEquals(raw json.RawMessage, want int64) bool {
+	return string(bytes.TrimSpace(raw)) == strconv.FormatInt(want, 10)
+}
+
+type boundedImportBuffer struct {
+	mu    sync.Mutex
+	limit int
+	data  []byte
+}
+
+func (buffer *boundedImportBuffer) Write(data []byte) (int, error) {
+	buffer.mu.Lock()
+	defer buffer.mu.Unlock()
+	remaining := buffer.limit - len(buffer.data)
+	if remaining > 0 {
+		if len(data) < remaining {
+			remaining = len(data)
+		}
+		buffer.data = append(buffer.data, data[:remaining]...)
+	}
+	return len(data), nil
+}
+
+func (buffer *boundedImportBuffer) String() string {
+	buffer.mu.Lock()
+	defer buffer.mu.Unlock()
+	return string(buffer.data)
+}
+
+func boundedImportText(value string) string {
+	if len(value) <= importErrorMax {
+		return value
+	}
+	return value[:importErrorMax] + "…"
+}

--- a/internal/session/import_codex.go
+++ b/internal/session/import_codex.go
@@ -177,13 +177,13 @@ func verifyCodexRPCThread(target Row, thread struct {
 	CWD  string `json:"cwd"`
 }) error {
 	if thread.ID != target.ID {
-		return fmt.Errorf("Codex app-server returned thread %q, want exact target %q", thread.ID, target.ID)
+		return fmt.Errorf("codex app-server returned thread %q, want exact target %q", thread.ID, target.ID)
 	}
 	if !sameImportPath(thread.Path, target.File) {
-		return fmt.Errorf("Codex app-server returned a different native session file: %s", boundedImportText(thread.Path))
+		return fmt.Errorf("codex app-server returned a different native session file: %s", boundedImportText(thread.Path))
 	}
 	if !sameImportPath(thread.CWD, target.CWD) {
-		return fmt.Errorf("Codex app-server returned a different workspace: %s", boundedImportText(thread.CWD))
+		return fmt.Errorf("codex app-server returned a different workspace: %s", boundedImportText(thread.CWD))
 	}
 	return nil
 }
@@ -233,7 +233,7 @@ func verifyCodexImportPersistence(path string, before ImportRevision, messages [
 
 	remaining := make(map[importMessageKey]int, len(messages))
 	for _, message := range messages {
-		remaining[importMessageKey{Role: message.Role, Text: message.Text}]++
+		remaining[importMessageKey(message)]++
 	}
 	scanner := bufio.NewScanner(io.TeeReader(file, fullHash))
 	scanner.Buffer(make([]byte, 64*1024), scanBufferMax)

--- a/internal/session/import_codex.go
+++ b/internal/session/import_codex.go
@@ -122,8 +122,9 @@ func applyCodexContextImport(parent context.Context, plan ImportPlan) (ImportRec
 
 	var resumed codexImportThreadResult
 	if err := client.call(ctx, "thread/resume", map[string]any{
-		"threadId": plan.Target.ID,
-		"cwd":      plan.Target.CWD,
+		"threadId":     plan.Target.ID,
+		"cwd":          plan.Target.CWD,
+		"excludeTurns": true,
 	}, &resumed); err != nil {
 		return ImportReceipt{}, codexImportPreWriteError(err)
 	}

--- a/internal/session/import_codex.go
+++ b/internal/session/import_codex.go
@@ -323,6 +323,7 @@ type codexImportRPCClient struct {
 	stdin     io.WriteCloser
 	responses chan codexImportRPCRead
 	done      chan struct{}
+	finished  chan struct{}
 	stderr    *boundedImportBuffer
 
 	mu        sync.Mutex
@@ -368,7 +369,7 @@ func startCodexImportClient(ctx context.Context, cwd string) (*codexImportRPCCli
 
 	client := &codexImportRPCClient{
 		command: command, stdin: stdin, responses: make(chan codexImportRPCRead, 64),
-		done: make(chan struct{}), stderr: stderr,
+		done: make(chan struct{}), finished: make(chan struct{}), stderr: stderr,
 	}
 	go client.read(stdout)
 	go func() {
@@ -387,13 +388,24 @@ func (client *codexImportRPCClient) read(stdout io.Reader) {
 	for scanner.Scan() {
 		var response codexImportRPCResponse
 		if err := json.Unmarshal(scanner.Bytes(), &response); err != nil {
-			client.responses <- codexImportRPCRead{err: fmt.Errorf("decode Codex app-server response: %w", err)}
+			client.publish(codexImportRPCRead{err: fmt.Errorf("decode Codex app-server response: %w", err)})
 			return
 		}
-		client.responses <- codexImportRPCRead{response: response}
+		if !client.publish(codexImportRPCRead{response: response}) {
+			return
+		}
 	}
 	if err := scanner.Err(); err != nil {
-		client.responses <- codexImportRPCRead{err: fmt.Errorf("read Codex app-server response: %w", err)}
+		client.publish(codexImportRPCRead{err: fmt.Errorf("read Codex app-server response: %w", err)})
+	}
+}
+
+func (client *codexImportRPCClient) publish(read codexImportRPCRead) bool {
+	select {
+	case client.responses <- read:
+		return true
+	case <-client.finished:
+		return false
 	}
 }
 
@@ -458,6 +470,7 @@ func (client *codexImportRPCClient) notify(method string) error {
 
 func (client *codexImportRPCClient) closeClient() {
 	client.closeOnce.Do(func() {
+		close(client.finished)
 		_ = client.stdin.Close()
 		select {
 		case <-client.done:

--- a/internal/session/import_codex.go
+++ b/internal/session/import_codex.go
@@ -411,7 +411,7 @@ func (client *codexImportRPCClient) call(ctx context.Context, method string, par
 	for {
 		select {
 		case <-callCtx.Done():
-			return fmt.Errorf("Codex app-server %s timed out: %w", method, callCtx.Err())
+			return fmt.Errorf("codex app-server %s timed out: %w", method, callCtx.Err())
 		case <-client.done:
 			return client.processError(fmt.Sprintf("Codex app-server exited during %s", method), nil)
 		case read := <-client.responses:
@@ -428,7 +428,7 @@ func (client *codexImportRPCClient) call(ctx context.Context, method string, par
 				if len(read.response.Error.Data) > 0 && string(read.response.Error.Data) != "null" {
 					message += ": " + boundedImportText(string(read.response.Error.Data))
 				}
-				return fmt.Errorf("Codex app-server %s error %d: %s", method, read.response.Error.Code, message)
+				return fmt.Errorf("codex app-server %s error %d: %s", method, read.response.Error.Code, message)
 			}
 			if result != nil && len(read.response.Result) > 0 && string(read.response.Result) != "null" {
 				if err := json.Unmarshal(read.response.Result, result); err != nil {

--- a/internal/session/import_codex.go
+++ b/internal/session/import_codex.go
@@ -88,7 +88,7 @@ func applyCodexContextImport(parent context.Context, plan ImportPlan) (ImportRec
 
 	before, err := observeImportRevision(plan.Target.File)
 	if err != nil {
-		return ImportReceipt{}, err
+		return ImportReceipt{}, codexImportPreWriteError(err)
 	}
 	if !sameImportRevision(plan.ObservedRevision, before) {
 		return ImportReceipt{}, ErrImportTargetChanged
@@ -96,7 +96,7 @@ func applyCodexContextImport(parent context.Context, plan ImportPlan) (ImportRec
 
 	client, err := startCodexImportClient(ctx, plan.Target.CWD)
 	if err != nil {
-		return ImportReceipt{}, err
+		return ImportReceipt{}, codexImportPreWriteError(err)
 	}
 	defer client.close()
 
@@ -104,20 +104,20 @@ func applyCodexContextImport(parent context.Context, plan ImportPlan) (ImportRec
 		"clientInfo":   map[string]string{"name": "showagent-import", "version": "1"},
 		"capabilities": map[string]bool{"experimentalApi": true},
 	}, nil); err != nil {
-		return ImportReceipt{}, err
+		return ImportReceipt{}, codexImportPreWriteError(err)
 	}
 	if err := client.notify("initialized"); err != nil {
-		return ImportReceipt{}, err
+		return ImportReceipt{}, codexImportPreWriteError(err)
 	}
 
 	var read codexImportThreadResult
 	if err := client.call(ctx, "thread/read", map[string]any{
 		"threadId": plan.Target.ID, "includeTurns": false,
 	}, &read); err != nil {
-		return ImportReceipt{}, err
+		return ImportReceipt{}, codexImportPreWriteError(err)
 	}
 	if err := verifyCodexRPCThread(plan.Target, read.Thread); err != nil {
-		return ImportReceipt{}, err
+		return ImportReceipt{}, codexImportPreWriteError(err)
 	}
 
 	var resumed codexImportThreadResult
@@ -125,10 +125,10 @@ func applyCodexContextImport(parent context.Context, plan ImportPlan) (ImportRec
 		"threadId": plan.Target.ID,
 		"cwd":      plan.Target.CWD,
 	}, &resumed); err != nil {
-		return ImportReceipt{}, err
+		return ImportReceipt{}, codexImportPreWriteError(err)
 	}
 	if err := verifyCodexRPCThread(plan.Target, resumed.Thread); err != nil {
-		return ImportReceipt{}, err
+		return ImportReceipt{}, codexImportPreWriteError(err)
 	}
 
 	items := codexImportItems(plan.messages)
@@ -154,6 +154,10 @@ func applyCodexContextImport(parent context.Context, plan ImportPlan) (ImportRec
 	receipt.BeforeRevision = before
 	receipt.AfterRevision = after
 	return receipt, nil
+}
+
+func codexImportPreWriteError(err error) error {
+	return fmt.Errorf("%w: %w", errImportNotStarted, err)
 }
 
 func importContext(parent context.Context) (context.Context, context.CancelFunc) {

--- a/internal/session/import_codex_test.go
+++ b/internal/session/import_codex_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -98,6 +99,41 @@ func TestApplyImportReadsCodexThreadWithoutTurns(t *testing.T) {
 	}
 	if methods := readMethodLog(t, logPath); !containsString(methods, "thread/inject_items") {
 		t.Fatalf("import did not reach injection after metadata-only thread/read: %#v", methods)
+	}
+}
+
+func TestApplyImportCodexStartFailureRemainsRetryable(t *testing.T) {
+	target, _ := writeCodexImportTarget(t)
+	t.Setenv("PATH", t.TempDir())
+
+	previousCommand := codexAppServerCommand
+	codexAppServerCommand = func(ctx context.Context, cwd string) *exec.Cmd {
+		command := exec.CommandContext(ctx, "codex", "app-server", "--stdio")
+		command.Dir = cwd
+		return command
+	}
+	defer func() { codexAppServerCommand = previousCommand }()
+
+	plan, err := PlanImport(ImportRequest{
+		Mode: ImportAppendContext, Target: target,
+		Messages: []ImportMessage{{Role: "user", Text: "retry after installing Codex"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		_, err = ApplyImport(context.Background(), plan)
+		if !errors.Is(err, errImportNotStarted) {
+			t.Fatalf("attempt %d error = %v, want pre-write failure", attempt, err)
+		}
+		if errors.Is(err, ErrImportOutcomeUncertain) {
+			t.Fatalf("attempt %d became outcome-uncertain before app-server start", attempt)
+		}
+	}
+	receipts, err := filepath.Glob(filepath.Join(os.Getenv("SHOWAGENT_STATE_DIR"), "imports", "*.json"))
+	if err != nil || len(receipts) != 0 {
+		t.Fatalf("pre-write failure left receipts = %#v, err=%v", receipts, err)
 	}
 }
 

--- a/internal/session/import_codex_test.go
+++ b/internal/session/import_codex_test.go
@@ -1,0 +1,464 @@
+package session
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestApplyImportAppendsCodexContextWithSameIDAndNoModelTurn(t *testing.T) {
+	target, original := writeCodexImportTarget(t)
+	logPath := filepath.Join(t.TempDir(), "methods.log")
+	installFakeCodexAppServer(t, target, logPath, fakeCodexAppServerOptions{})
+
+	messages := []ImportMessage{
+		{Role: "user", Text: "Imported question. Türkçe\r\n```text\r\n  keep spaces\r\n```"},
+		{Role: "assistant", Text: "Imported answer."},
+	}
+	plan, err := PlanImport(ImportRequest{
+		Mode:     ImportAppendContext,
+		Target:   target,
+		Messages: messages,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := ApplyImport(context.Background(), plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Row.ID != target.ID || receipt.Row.Provider != ProviderCodex {
+		t.Fatalf("receipt target = %#v, want same Codex id %q", receipt.Row, target.ID)
+	}
+	if receipt.NativeHistoryVisible {
+		t.Fatal("Codex injected context must not claim native chat-bubble visibility")
+	}
+
+	after, err := os.ReadFile(target.File)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(string(after), string(original)) {
+		t.Fatal("original target bytes are not an exact prefix after append")
+	}
+	wantMethods := []string{"initialize", "initialized", "thread/read", "thread/resume", "thread/inject_items", "thread/unsubscribe"}
+	methods := readMethodLog(t, logPath)
+	if !reflect.DeepEqual(methods, wantMethods) {
+		t.Fatalf("app-server methods = %#v, want %#v", methods, wantMethods)
+	}
+	for _, forbidden := range []string{"turn/start", "turn/steer", "exec"} {
+		if strings.Contains(strings.Join(methods, "\n"), forbidden) {
+			t.Fatalf("model/runtime method %q was called", forbidden)
+		}
+	}
+
+	repeatPlan, err := PlanImport(ImportRequest{
+		Mode: ImportAppendContext, Target: target, Messages: messages,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	repeat, err := ApplyImport(context.Background(), repeatPlan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !repeat.NoOp || repeat.Row.ID != target.ID {
+		t.Fatalf("repeat receipt = %#v, want verified same-ID no-op", repeat)
+	}
+	if repeatedMethods := readMethodLog(t, logPath); !reflect.DeepEqual(repeatedMethods, wantMethods) {
+		t.Fatalf("duplicate import called app-server again: %#v", repeatedMethods)
+	}
+}
+
+func TestApplyImportReadsCodexThreadWithoutTurns(t *testing.T) {
+	target, _ := writeCodexImportTarget(t)
+	logPath := filepath.Join(t.TempDir(), "methods.log")
+	installFakeCodexAppServer(t, target, logPath, fakeCodexAppServerOptions{
+		RejectThreadReadWithTurns: true,
+	})
+
+	plan, err := PlanImport(ImportRequest{
+		Mode:     ImportAppendContext,
+		Target:   target,
+		Messages: []ImportMessage{{Role: "user", Text: "small import"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ApplyImport(context.Background(), plan); err != nil {
+		t.Fatalf("ApplyImport loaded existing turns during thread/read: %v", err)
+	}
+	if methods := readMethodLog(t, logPath); !containsString(methods, "thread/inject_items") {
+		t.Fatalf("import did not reach injection after metadata-only thread/read: %#v", methods)
+	}
+}
+
+func TestApplyImportRejectsMismatchedCodexRPCThreadBeforeInjection(t *testing.T) {
+	tests := []struct {
+		name      string
+		method    string
+		field     string
+		wantError string
+	}{
+		{name: "read id", method: "thread/read", field: "id", wantError: "returned thread"},
+		{name: "read path", method: "thread/read", field: "path", wantError: "different native session file"},
+		{name: "read cwd", method: "thread/read", field: "cwd", wantError: "different workspace"},
+		{name: "resume id", method: "thread/resume", field: "id", wantError: "returned thread"},
+		{name: "resume path", method: "thread/resume", field: "path", wantError: "different native session file"},
+		{name: "resume cwd", method: "thread/resume", field: "cwd", wantError: "different workspace"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			target, _ := writeCodexImportTarget(t)
+			logPath := filepath.Join(t.TempDir(), "methods.log")
+			mismatch := target
+			switch test.field {
+			case "id":
+				mismatch.ID = "different-thread-id"
+			case "path":
+				mismatch.File = filepath.Join(t.TempDir(), "different-rollout.jsonl")
+			case "cwd":
+				mismatch.CWD = filepath.Join(t.TempDir(), "different-workspace")
+			default:
+				t.Fatalf("unknown mismatch field %q", test.field)
+			}
+
+			options := fakeCodexAppServerOptions{}
+			if test.method == "thread/read" {
+				options.ThreadReadTarget = &mismatch
+			} else {
+				options.ThreadResumeTarget = &mismatch
+			}
+			installFakeCodexAppServer(t, target, logPath, options)
+
+			plan, err := PlanImport(ImportRequest{
+				Mode:     ImportAppendContext,
+				Target:   target,
+				Messages: []ImportMessage{{Role: "assistant", Text: "must not be injected"}},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = ApplyImport(context.Background(), plan)
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("ApplyImport error = %v, want mismatch error containing %q", err, test.wantError)
+			}
+
+			methods := readMethodLog(t, logPath)
+			if containsString(methods, "thread/inject_items") {
+				t.Fatalf("mismatched %s %s reached injection: %#v", test.method, test.field, methods)
+			}
+			if !containsString(methods, test.method) {
+				t.Fatalf("fake server did not exercise %s mismatch: %#v", test.method, methods)
+			}
+		})
+	}
+}
+
+func TestApplyImportRequiresReviewAgainWhenTargetChangedAfterPlan(t *testing.T) {
+	target, _ := writeCodexImportTarget(t)
+	started := false
+	previous := codexAppServerCommand
+	codexAppServerCommand = func(ctx context.Context, cwd string) *exec.Cmd {
+		started = true
+		return previous(ctx, cwd)
+	}
+	t.Cleanup(func() { codexAppServerCommand = previous })
+
+	plan, err := PlanImport(ImportRequest{
+		Mode:     ImportAppendContext,
+		Target:   target,
+		Messages: []ImportMessage{{Role: "assistant", Text: "planned answer"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.OpenFile(target.File, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, writeErr := file.WriteString("{\"type\":\"external-change\"}\n")
+	closeErr := file.Close()
+	if writeErr != nil || closeErr != nil {
+		t.Fatalf("mutate target: write=%v close=%v", writeErr, closeErr)
+	}
+
+	_, err = ApplyImport(context.Background(), plan)
+	if err == nil || !errorsIs(err, ErrImportTargetChanged) || !strings.Contains(strings.ToLower(err.Error()), "review") {
+		t.Fatalf("ApplyImport error = %v, want review-again target change", err)
+	}
+	if started {
+		t.Fatal("app-server started even though the observed target revision changed")
+	}
+}
+
+func TestApplyImportReturnsBoundedCodexProtocolErrorAndCleansUp(t *testing.T) {
+	target, _ := writeCodexImportTarget(t)
+	logPath := filepath.Join(t.TempDir(), "methods.log")
+	installFakeCodexAppServer(t, target, logPath, fakeCodexAppServerOptions{
+		ErrorMethod: "thread/inject_items",
+	})
+
+	plan, err := PlanImport(ImportRequest{
+		Mode:     ImportAppendContext,
+		Target:   target,
+		Messages: []ImportMessage{{Role: "user", Text: "will fail"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = ApplyImport(context.Background(), plan)
+	if err == nil || !strings.Contains(err.Error(), "thread/inject_items") {
+		t.Fatalf("ApplyImport error = %v", err)
+	}
+	if len(err.Error()) > importErrorMax+512 {
+		t.Fatalf("protocol error was not bounded: %d bytes", len(err.Error()))
+	}
+	methods := readMethodLog(t, logPath)
+	if !containsString(methods, "thread/unsubscribe") {
+		t.Fatalf("app-server was not unsubscribed after protocol error: %#v", methods)
+	}
+}
+
+func TestCodexAppServerHelperProcess(t *testing.T) {
+	if os.Getenv("SHOWAGENT_FAKE_CODEX_APP_SERVER") != "1" {
+		return
+	}
+
+	targetPath := os.Getenv("SHOWAGENT_FAKE_CODEX_TARGET")
+	logPath := os.Getenv("SHOWAGENT_FAKE_CODEX_LOG")
+	errorMethod := os.Getenv("SHOWAGENT_FAKE_CODEX_ERROR_METHOD")
+	readTarget := Row{
+		ID:   os.Getenv("SHOWAGENT_FAKE_CODEX_READ_ID"),
+		File: os.Getenv("SHOWAGENT_FAKE_CODEX_READ_PATH"),
+		CWD:  os.Getenv("SHOWAGENT_FAKE_CODEX_READ_CWD"),
+	}
+	resumeTarget := Row{
+		ID:   os.Getenv("SHOWAGENT_FAKE_CODEX_RESUME_ID"),
+		File: os.Getenv("SHOWAGENT_FAKE_CODEX_RESUME_PATH"),
+		CWD:  os.Getenv("SHOWAGENT_FAKE_CODEX_RESUME_CWD"),
+	}
+	rejectThreadReadWithTurns := os.Getenv("SHOWAGENT_FAKE_CODEX_REJECT_READ_WITH_TURNS") == "true"
+
+	scanner := bufio.NewScanner(os.Stdin)
+	encoder := json.NewEncoder(os.Stdout)
+	for scanner.Scan() {
+		var request struct {
+			ID     int64           `json:"id"`
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &request); err != nil {
+			os.Exit(11)
+		}
+		appendFakeMethod(logPath, request.Method)
+		if request.ID == 0 {
+			continue
+		}
+		if request.Method == errorMethod {
+			_ = encoder.Encode(map[string]any{"id": request.ID, "error": map[string]any{
+				"code": -32001, "message": "fake protocol failure " + strings.Repeat("x", importErrorMax*2),
+			}})
+			continue
+		}
+
+		var result any = map[string]any{}
+		switch request.Method {
+		case "initialize":
+		case "thread/read":
+			if rejectThreadReadWithTurns {
+				var params struct {
+					IncludeTurns *bool `json:"includeTurns"`
+				}
+				if err := json.Unmarshal(request.Params, &params); err != nil {
+					os.Exit(18)
+				}
+				if params.IncludeTurns != nil && *params.IncludeTurns {
+					_ = encoder.Encode(map[string]any{"id": request.ID, "error": map[string]any{
+						"code": -32602, "message": "thread/read must not load existing turns",
+					}})
+					continue
+				}
+			}
+			result = map[string]any{"thread": map[string]any{
+				"id": readTarget.ID, "path": readTarget.File, "cwd": readTarget.CWD,
+			}}
+		case "thread/resume":
+			result = map[string]any{"thread": map[string]any{
+				"id": resumeTarget.ID, "path": resumeTarget.File, "cwd": resumeTarget.CWD,
+			}}
+		case "thread/inject_items":
+			var params struct {
+				Items []map[string]any `json:"items"`
+			}
+			if err := json.Unmarshal(request.Params, &params); err != nil {
+				os.Exit(12)
+			}
+			file, err := os.OpenFile(targetPath, os.O_APPEND|os.O_WRONLY, 0)
+			if err != nil {
+				os.Exit(13)
+			}
+			fileEncoder := json.NewEncoder(file)
+			for _, item := range params.Items {
+				if err := fileEncoder.Encode(map[string]any{
+					"timestamp": time.Now().UTC().Format(time.RFC3339Nano),
+					"type":      "response_item",
+					"payload":   item,
+				}); err != nil {
+					os.Exit(14)
+				}
+			}
+			if err := file.Close(); err != nil {
+				os.Exit(15)
+			}
+		case "thread/unsubscribe":
+			result = map[string]any{"status": "unsubscribed"}
+		default:
+			_ = encoder.Encode(map[string]any{"id": request.ID, "error": map[string]any{
+				"code": -32601, "message": "unexpected method " + request.Method,
+			}})
+			continue
+		}
+		if err := encoder.Encode(map[string]any{"id": request.ID, "result": result}); err != nil {
+			os.Exit(16)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		os.Exit(17)
+	}
+	os.Exit(0)
+}
+
+func writeCodexImportTarget(t *testing.T) (Row, []byte) {
+	t.Helper()
+	root := t.TempDir()
+	workspace := filepath.Join(root, "project")
+	if err := makeTestDir(workspace); err != nil {
+		t.Fatal(err)
+	}
+	codexHome := filepath.Join(root, "codex")
+	t.Setenv("CODEX_HOME", codexHome)
+	t.Setenv("SHOWAGENT_STATE_DIR", filepath.Join(root, "showagent-state"))
+	id := "5287a80e-3fea-4624-ae1b-434f23abc951"
+	path := filepath.Join(codexHome, "sessions", "2026", "09", "08", "rollout-2026-09-08T08-26-31-"+id+".jsonl")
+	if err := makeTestDir(filepath.Dir(path)); err != nil {
+		t.Fatal(err)
+	}
+	records := []map[string]any{
+		{"timestamp": "2026-09-08T08:26:31Z", "type": "session_meta", "payload": map[string]any{
+			"id": id, "timestamp": "2026-09-08T08:26:31Z", "cwd": workspace,
+			"originator": "showagent", "source": "cli", "thread_source": "user",
+		}},
+		{"timestamp": "2026-09-08T08:26:32Z", "type": "response_item", "payload": map[string]any{
+			"type": "message", "role": "user", "content": []map[string]string{{"type": "input_text", "text": "original request"}},
+		}},
+		{"timestamp": "2026-09-08T08:26:33Z", "type": "response_item", "payload": map[string]any{
+			"type": "message", "role": "assistant", "content": []map[string]string{{"type": "output_text", "text": "original answer"}},
+		}},
+	}
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoder := json.NewEncoder(file)
+	encoder.SetEscapeHTML(false)
+	for _, record := range records {
+		if err := encoder.Encode(record); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	original, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return Row{Provider: ProviderCodex, ID: id, CWD: workspace, LaunchCWD: workspace, File: path}, original
+}
+
+type fakeCodexAppServerOptions struct {
+	ErrorMethod               string
+	RejectThreadReadWithTurns bool
+	ThreadReadTarget          *Row
+	ThreadResumeTarget        *Row
+}
+
+func installFakeCodexAppServer(t *testing.T, target Row, logPath string, options fakeCodexAppServerOptions) {
+	t.Helper()
+	readTarget := target
+	if options.ThreadReadTarget != nil {
+		readTarget = *options.ThreadReadTarget
+	}
+	resumeTarget := target
+	if options.ThreadResumeTarget != nil {
+		resumeTarget = *options.ThreadResumeTarget
+	}
+	previous := codexAppServerCommand
+	codexAppServerCommand = func(ctx context.Context, cwd string) *exec.Cmd {
+		command := exec.CommandContext(ctx, os.Args[0], "-test.run=TestCodexAppServerHelperProcess", "--")
+		command.Dir = cwd
+		command.Env = append(os.Environ(),
+			"SHOWAGENT_FAKE_CODEX_APP_SERVER=1",
+			"SHOWAGENT_FAKE_CODEX_TARGET="+target.File,
+			"SHOWAGENT_FAKE_CODEX_LOG="+logPath,
+			"SHOWAGENT_FAKE_CODEX_ERROR_METHOD="+options.ErrorMethod,
+			"SHOWAGENT_FAKE_CODEX_READ_ID="+readTarget.ID,
+			"SHOWAGENT_FAKE_CODEX_READ_PATH="+readTarget.File,
+			"SHOWAGENT_FAKE_CODEX_READ_CWD="+readTarget.CWD,
+			"SHOWAGENT_FAKE_CODEX_RESUME_ID="+resumeTarget.ID,
+			"SHOWAGENT_FAKE_CODEX_RESUME_PATH="+resumeTarget.File,
+			"SHOWAGENT_FAKE_CODEX_RESUME_CWD="+resumeTarget.CWD,
+			fmt.Sprintf("SHOWAGENT_FAKE_CODEX_REJECT_READ_WITH_TURNS=%t", options.RejectThreadReadWithTurns),
+		)
+		return command
+	}
+	t.Cleanup(func() { codexAppServerCommand = previous })
+}
+
+func appendFakeMethod(path, method string) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		os.Exit(21)
+	}
+	_, err = fmt.Fprintln(file, method)
+	closeErr := file.Close()
+	if err != nil || closeErr != nil {
+		os.Exit(22)
+	}
+}
+
+func readMethodLog(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.Fields(string(data))
+}
+
+func makeTestDir(path string) error {
+	return os.MkdirAll(path, 0o700)
+}
+
+func errorsIs(err, target error) bool {
+	return err != nil && (err == target || strings.Contains(err.Error(), target.Error()))
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/session/import_codex_test.go
+++ b/internal/session/import_codex_test.go
@@ -265,6 +265,32 @@ func TestApplyImportReturnsBoundedCodexProtocolErrorAndCleansUp(t *testing.T) {
 	}
 }
 
+func TestCodexImportRPCReaderStopsWhenClientFinishes(t *testing.T) {
+	client := &codexImportRPCClient{
+		responses: make(chan codexImportRPCRead, 1),
+		finished:  make(chan struct{}),
+	}
+	readerDone := make(chan struct{})
+	go func() {
+		client.read(strings.NewReader(strings.Repeat("{\"id\":1,\"result\":{}}\n", 128)))
+		close(readerDone)
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for len(client.responses) == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if len(client.responses) == 0 {
+		t.Fatal("reader did not fill its response buffer")
+	}
+	close(client.finished)
+	select {
+	case <-readerDone:
+	case <-time.After(time.Second):
+		t.Fatal("reader stayed blocked on a full response buffer after client shutdown")
+	}
+}
+
 func TestCodexAppServerHelperProcess(t *testing.T) {
 	if os.Getenv("SHOWAGENT_FAKE_CODEX_APP_SERVER") != "1" {
 		return

--- a/internal/session/import_codex_test.go
+++ b/internal/session/import_codex_test.go
@@ -102,6 +102,29 @@ func TestApplyImportReadsCodexThreadWithoutTurns(t *testing.T) {
 	}
 }
 
+func TestApplyImportResumesCodexThreadWithoutTurns(t *testing.T) {
+	target, _ := writeCodexImportTarget(t)
+	logPath := filepath.Join(t.TempDir(), "methods.log")
+	installFakeCodexAppServer(t, target, logPath, fakeCodexAppServerOptions{
+		RejectThreadResumeWithTurns: true,
+	})
+
+	plan, err := PlanImport(ImportRequest{
+		Mode:     ImportAppendContext,
+		Target:   target,
+		Messages: []ImportMessage{{Role: "user", Text: "small import into a long conversation"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ApplyImport(context.Background(), plan); err != nil {
+		t.Fatalf("ApplyImport loaded existing turns during thread/resume: %v", err)
+	}
+	if methods := readMethodLog(t, logPath); !containsString(methods, "thread/inject_items") {
+		t.Fatalf("import did not reach injection after metadata-only thread/resume: %#v", methods)
+	}
+}
+
 func TestApplyImportCodexStartFailureRemainsRetryable(t *testing.T) {
 	target, _ := writeCodexImportTarget(t)
 	t.Setenv("PATH", t.TempDir())
@@ -310,6 +333,7 @@ func TestCodexAppServerHelperProcess(t *testing.T) {
 		CWD:  os.Getenv("SHOWAGENT_FAKE_CODEX_RESUME_CWD"),
 	}
 	rejectThreadReadWithTurns := os.Getenv("SHOWAGENT_FAKE_CODEX_REJECT_READ_WITH_TURNS") == "true"
+	rejectThreadResumeWithTurns := os.Getenv("SHOWAGENT_FAKE_CODEX_REJECT_RESUME_WITH_TURNS") == "true"
 
 	scanner := bufio.NewScanner(os.Stdin)
 	encoder := json.NewEncoder(os.Stdout)
@@ -355,6 +379,20 @@ func TestCodexAppServerHelperProcess(t *testing.T) {
 				"id": readTarget.ID, "path": readTarget.File, "cwd": readTarget.CWD,
 			}}
 		case "thread/resume":
+			if rejectThreadResumeWithTurns {
+				var params struct {
+					ExcludeTurns bool `json:"excludeTurns"`
+				}
+				if err := json.Unmarshal(request.Params, &params); err != nil {
+					os.Exit(19)
+				}
+				if !params.ExcludeTurns {
+					_ = encoder.Encode(map[string]any{"id": request.ID, "error": map[string]any{
+						"code": -32602, "message": "thread/resume must not hydrate existing turns",
+					}})
+					continue
+				}
+			}
 			result = map[string]any{"thread": map[string]any{
 				"id": resumeTarget.ID, "path": resumeTarget.File, "cwd": resumeTarget.CWD,
 			}}
@@ -449,10 +487,11 @@ func writeCodexImportTarget(t *testing.T) (Row, []byte) {
 }
 
 type fakeCodexAppServerOptions struct {
-	ErrorMethod               string
-	RejectThreadReadWithTurns bool
-	ThreadReadTarget          *Row
-	ThreadResumeTarget        *Row
+	ErrorMethod                 string
+	RejectThreadReadWithTurns   bool
+	RejectThreadResumeWithTurns bool
+	ThreadReadTarget            *Row
+	ThreadResumeTarget          *Row
 }
 
 func installFakeCodexAppServer(t *testing.T, target Row, logPath string, options fakeCodexAppServerOptions) {
@@ -481,6 +520,7 @@ func installFakeCodexAppServer(t *testing.T, target Row, logPath string, options
 			"SHOWAGENT_FAKE_CODEX_RESUME_PATH="+resumeTarget.File,
 			"SHOWAGENT_FAKE_CODEX_RESUME_CWD="+resumeTarget.CWD,
 			fmt.Sprintf("SHOWAGENT_FAKE_CODEX_REJECT_READ_WITH_TURNS=%t", options.RejectThreadReadWithTurns),
+			fmt.Sprintf("SHOWAGENT_FAKE_CODEX_REJECT_RESUME_WITH_TURNS=%t", options.RejectThreadResumeWithTurns),
 		)
 		return command
 	}

--- a/internal/session/import_receipt.go
+++ b/internal/session/import_receipt.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -162,22 +163,28 @@ func verifiedCommittedImport(plan ImportPlan, stored storedImportReceipt) (Impor
 		if !ok {
 			return ImportReceipt{}, fmt.Errorf("%w: provider is unavailable", ErrImportVerification)
 		}
-		row = Row{}
-		for _, candidate := range impl.Discover() {
-			if candidate.ID == stored.TargetID {
-				row = candidate
-				break
-			}
+		var err error
+		row, err = importCreateReceiptTarget(impl, plan, stored.TargetID)
+		if err != nil {
+			return ImportReceipt{}, err
 		}
-		if row.ID == "" {
-			return ImportReceipt{}, fmt.Errorf("%w: committed target session %q is missing", ErrImportVerification, stored.TargetID)
+		if !sameImportPath(row.CWD, plan.CWD) {
+			return ImportReceipt{}, fmt.Errorf("%w: committed target session is in a different workspace", ErrImportVerification)
 		}
-		turns, err := impl.Transcript(row)
+		prefixIntact, err := committedImportPrefixIntact(row.File, stored.AfterRevision)
 		if err != nil {
 			return ImportReceipt{}, fmt.Errorf("%w: read committed target: %v", ErrImportVerification, err)
 		}
-		if !importMessagesAtStart(turns, plan.messages) {
-			return ImportReceipt{}, fmt.Errorf("%w: committed target no longer contains the imported messages", ErrImportVerification)
+		if !prefixIntact {
+			// Some providers rewrite whole-session JSON files on continuation;
+			// OpenCode has no native file. Retain transcript verification there.
+			turns, err := impl.Transcript(row)
+			if err != nil {
+				return ImportReceipt{}, fmt.Errorf("%w: read committed target: %v", ErrImportVerification, err)
+			}
+			if !importMessagesAtStart(turns, plan.messages) {
+				return ImportReceipt{}, fmt.Errorf("%w: committed target no longer contains the imported messages", ErrImportVerification)
+			}
 		}
 	} else {
 		if row.ID != stored.TargetID {
@@ -200,6 +207,87 @@ func verifiedCommittedImport(plan ImportPlan, stored storedImportReceipt) (Impor
 		NativeHistoryVisible: stored.NativeHistoryVisible,
 		NoOp:                 true,
 	}, nil
+}
+
+func importCreateReceiptTarget(impl ProviderImpl, plan ImportPlan, id string) (Row, error) {
+	if plan.Provider == ProviderJCode {
+		// JCode's picker intentionally requires its CLI and a useful user
+		// preview. Neither is needed to verify our own local imported session.
+		return importJCodeReceiptTarget(plan.CWD, id)
+	}
+	for _, candidate := range impl.Discover() {
+		if candidate.ID == id {
+			return candidate, nil
+		}
+	}
+	return Row{}, fmt.Errorf("%w: committed target session %q is missing", ErrImportVerification, id)
+}
+
+func importJCodeReceiptTarget(cwd, id string) (Row, error) {
+	// IDs are receipt data, not paths. Exclude separators, traversal and
+	// Windows alternate stream syntax before constructing the native path.
+	if id == "" {
+		return Row{}, fmt.Errorf("%w: committed JCode target id is empty", ErrImportVerification)
+	}
+	for _, character := range id {
+		if !(character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' || character >= '0' && character <= '9' || character == '_' || character == '-') {
+			return Row{}, fmt.Errorf("%w: committed JCode target id is invalid", ErrImportVerification)
+		}
+	}
+	store, err := filepath.EvalSymlinks(filepath.Join(defaultJCodeHome(), "sessions"))
+	if err != nil {
+		return Row{}, fmt.Errorf("%w: committed JCode store is unavailable: %v", ErrImportVerification, err)
+	}
+	path, err := filepath.EvalSymlinks(filepath.Join(store, id+".json"))
+	if err != nil {
+		return Row{}, fmt.Errorf("%w: committed JCode target is unavailable: %v", ErrImportVerification, err)
+	}
+	if !pathWithin(store, path) {
+		return Row{}, fmt.Errorf("%w: committed JCode target is outside its native store", ErrImportVerification)
+	}
+	native, ok := readJCodeSession(path)
+	if !ok || native.ID != id {
+		return Row{}, fmt.Errorf("%w: committed JCode target identity changed", ErrImportVerification)
+	}
+	if native.WorkingDir == "" || !sameImportPath(native.WorkingDir, cwd) {
+		return Row{}, fmt.Errorf("%w: committed target session is in a different workspace", ErrImportVerification)
+	}
+	firstUser, lastUser := jcodeUserPreviews(native.Messages)
+	lastAt, ok := parseTimestamp(native.UpdatedAt)
+	if !ok {
+		lastAt, _ = parseTimestamp(native.CreatedAt)
+	}
+	return Row{
+		Provider: ProviderJCode, ID: native.ID, CWD: native.WorkingDir,
+		LaunchCWD: native.WorkingDir, File: path, LastAt: lastAt,
+		FirstUser: firstUser, LastUser: lastUser,
+	}, nil
+}
+
+// An intact native prefix proves the original import still exists, including
+// arbitrary user text that the ordinary transcript reader filters as provider
+// boilerplate. It also accepts a safely continued, append-only native session.
+func committedImportPrefixIntact(path string, revision ImportRevision) (bool, error) {
+	if path == "" || revision.Size <= 0 || revision.SHA256 == "" {
+		return false, nil
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
+	if err != nil {
+		return false, err
+	}
+	if !info.Mode().IsRegular() || info.Size() < revision.Size {
+		return false, nil
+	}
+	hash := sha256.New()
+	if _, err := io.CopyN(hash, file, revision.Size); err != nil {
+		return false, err
+	}
+	return hex.EncodeToString(hash.Sum(nil)) == revision.SHA256, nil
 }
 
 func importMessagesAtStart(turns []Turn, messages []ImportMessage) bool {

--- a/internal/session/import_receipt.go
+++ b/internal/session/import_receipt.go
@@ -1,0 +1,267 @@
+package session
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const (
+	importReceiptVersion   = 1
+	importReceiptPrepared  = "prepared"
+	importReceiptCommitted = "committed"
+	importRepresentation   = "role_text_v1"
+)
+
+type storedImportReceipt struct {
+	Version              int            `json:"version"`
+	Key                  string         `json:"key"`
+	Status               string         `json:"status"`
+	OperationID          string         `json:"operation_id"`
+	Mode                 ImportMode     `json:"mode"`
+	Provider             Provider       `json:"provider"`
+	TargetID             string         `json:"target_id,omitempty"`
+	MessageCount         int            `json:"message_count"`
+	SourceSnapshotHash   string         `json:"source_snapshot_hash"`
+	Representation       string         `json:"representation"`
+	BeforeRevision       ImportRevision `json:"before_revision,omitempty"`
+	AfterRevision        ImportRevision `json:"after_revision,omitempty"`
+	NativeHistoryVisible bool           `json:"native_history_visible"`
+	CreatedAt            time.Time      `json:"created_at"`
+	CommittedAt          *time.Time     `json:"committed_at,omitempty"`
+}
+
+func prepareImportReceipt(plan ImportPlan) (*storedImportReceipt, string, error) {
+	directory, err := importReceiptDirectory()
+	if err != nil {
+		return nil, "", err
+	}
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		return nil, "", fmt.Errorf("create import receipt directory: %w", err)
+	}
+	key := importReceiptKey(plan)
+	path := filepath.Join(directory, key+".prepared.json")
+	committedPath := committedImportReceiptPath(path)
+	if stored, err := readStoredImportReceipt(committedPath); err == nil {
+		if stored.Status != importReceiptCommitted {
+			return nil, path, fmt.Errorf("committed import receipt has unknown status %q", stored.Status)
+		}
+		return &stored, path, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, path, err
+	}
+	if stored, err := readStoredImportReceipt(path); err == nil {
+		if stored.Status == importReceiptPrepared {
+			return nil, path, ErrImportOutcomeUncertain
+		}
+		return nil, path, fmt.Errorf("prepared import receipt has unknown status %q", stored.Status)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, path, err
+	}
+
+	prepared := storedImportReceipt{
+		Version:              importReceiptVersion,
+		Key:                  key,
+		Status:               importReceiptPrepared,
+		OperationID:          plan.OperationID,
+		Mode:                 plan.Mode,
+		Provider:             plan.Provider,
+		MessageCount:         plan.MessageCount,
+		SourceSnapshotHash:   plan.SourceSnapshotHash,
+		Representation:       importRepresentation,
+		BeforeRevision:       plan.ObservedRevision,
+		NativeHistoryVisible: plan.Capability.NativeHistoryVisible,
+		CreatedAt:            time.Now().UTC(),
+	}
+	if plan.Mode == ImportAppendContext {
+		prepared.TargetID = plan.Target.ID
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if errors.Is(err, os.ErrExist) {
+		return prepareImportReceipt(plan)
+	}
+	if err != nil {
+		return nil, path, fmt.Errorf("prepare import receipt: %w", err)
+	}
+	remove := true
+	defer func() {
+		_ = file.Close()
+		if remove {
+			_ = os.Remove(path)
+		}
+	}()
+	encoder := json.NewEncoder(file)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(prepared); err != nil {
+		return nil, path, fmt.Errorf("write prepared import receipt: %w", err)
+	}
+	if err := file.Chmod(0o600); err != nil {
+		return nil, path, fmt.Errorf("protect prepared import receipt: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		return nil, path, fmt.Errorf("sync prepared import receipt: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return nil, path, fmt.Errorf("close prepared import receipt: %w", err)
+	}
+	remove = false
+	return nil, path, nil
+}
+
+func commitImportReceipt(path string, receipt ImportReceipt) error {
+	stored, err := readStoredImportReceipt(path)
+	if err != nil {
+		return err
+	}
+	if stored.Status != importReceiptPrepared || stored.OperationID != receipt.OperationID {
+		return errors.New("prepared import receipt no longer matches the completed operation")
+	}
+	now := time.Now().UTC()
+	stored.Status = importReceiptCommitted
+	stored.TargetID = receipt.Row.ID
+	stored.BeforeRevision = receipt.BeforeRevision
+	stored.AfterRevision = receipt.AfterRevision
+	stored.NativeHistoryVisible = receipt.NativeHistoryVisible
+	stored.CommittedAt = &now
+	committedPath := committedImportReceiptPath(path)
+	if err := writeFileAtomic(committedPath, func(file *os.File) error {
+		encoder := json.NewEncoder(file)
+		encoder.SetEscapeHTML(false)
+		return encoder.Encode(stored)
+	}); err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove prepared import receipt: %w", err)
+	}
+	return nil
+}
+
+func committedImportReceiptPath(preparedPath string) string {
+	return strings.TrimSuffix(preparedPath, ".prepared.json") + ".committed.json"
+}
+
+func verifiedCommittedImport(plan ImportPlan, stored storedImportReceipt) (ImportReceipt, error) {
+	if stored.Version != importReceiptVersion || stored.Key != importReceiptKey(plan) ||
+		stored.Mode != plan.Mode || stored.Provider != plan.Provider ||
+		stored.SourceSnapshotHash != plan.SourceSnapshotHash || stored.MessageCount != plan.MessageCount ||
+		stored.Representation != importRepresentation {
+		return ImportReceipt{}, fmt.Errorf("%w: committed receipt does not match the reviewed import", ErrImportVerification)
+	}
+
+	row := plan.Target
+	if plan.Mode == ImportCreate {
+		impl, ok := providerFor(plan.Provider)
+		if !ok {
+			return ImportReceipt{}, fmt.Errorf("%w: provider is unavailable", ErrImportVerification)
+		}
+		row = Row{}
+		for _, candidate := range impl.Discover() {
+			if candidate.ID == stored.TargetID {
+				row = candidate
+				break
+			}
+		}
+		if row.ID == "" {
+			return ImportReceipt{}, fmt.Errorf("%w: committed target session %q is missing", ErrImportVerification, stored.TargetID)
+		}
+		turns, err := impl.Transcript(row)
+		if err != nil {
+			return ImportReceipt{}, fmt.Errorf("%w: read committed target: %v", ErrImportVerification, err)
+		}
+		if !importMessagesAtStart(turns, plan.messages) {
+			return ImportReceipt{}, fmt.Errorf("%w: committed target no longer contains the imported messages", ErrImportVerification)
+		}
+	} else {
+		if row.ID != stored.TargetID {
+			return ImportReceipt{}, fmt.Errorf("%w: committed target id changed", ErrImportVerification)
+		}
+		if _, err := verifyCodexImportPersistence(row.File, stored.BeforeRevision, plan.messages); err != nil {
+			return ImportReceipt{}, err
+		}
+	}
+
+	return ImportReceipt{
+		OperationID:          stored.OperationID,
+		Mode:                 stored.Mode,
+		Provider:             stored.Provider,
+		Row:                  row,
+		MessageCount:         stored.MessageCount,
+		SourceSnapshotHash:   stored.SourceSnapshotHash,
+		BeforeRevision:       stored.BeforeRevision,
+		AfterRevision:        stored.AfterRevision,
+		NativeHistoryVisible: stored.NativeHistoryVisible,
+		NoOp:                 true,
+	}, nil
+}
+
+func importMessagesAtStart(turns []Turn, messages []ImportMessage) bool {
+	if len(turns) < len(messages) {
+		return false
+	}
+	for index, message := range messages {
+		if turns[index].Role != message.Role || turns[index].Text != cleanTranscriptText(message.Text) {
+			return false
+		}
+	}
+	return true
+}
+
+func readStoredImportReceipt(path string) (storedImportReceipt, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return storedImportReceipt{}, err
+	}
+	var receipt storedImportReceipt
+	if err := json.Unmarshal(data, &receipt); err != nil {
+		return storedImportReceipt{}, fmt.Errorf("read import receipt: %w", err)
+	}
+	return receipt, nil
+}
+
+func importReceiptKey(plan ImportPlan) string {
+	scope := plan.CWD
+	if plan.Mode == ImportAppendContext {
+		scope = plan.Target.ID
+	}
+	data, _ := json.Marshal(struct {
+		Version        int        `json:"version"`
+		Mode           ImportMode `json:"mode"`
+		Provider       Provider   `json:"provider"`
+		Scope          string     `json:"scope"`
+		Snapshot       string     `json:"snapshot"`
+		Representation string     `json:"representation"`
+	}{importReceiptVersion, plan.Mode, plan.Provider, scope, plan.SourceSnapshotHash, importRepresentation})
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func importReceiptDirectory() (string, error) {
+	if override := strings.TrimSpace(os.Getenv("SHOWAGENT_STATE_DIR")); override != "" {
+		absolute, err := filepath.Abs(override)
+		if err != nil {
+			return "", fmt.Errorf("resolve SHOWAGENT_STATE_DIR: %w", err)
+		}
+		return filepath.Join(absolute, "imports"), nil
+	}
+	if runtime.GOOS == "windows" {
+		if local := strings.TrimSpace(os.Getenv("LOCALAPPDATA")); local != "" {
+			return filepath.Join(local, "showagent", "imports"), nil
+		}
+	}
+	if state := strings.TrimSpace(os.Getenv("XDG_STATE_HOME")); state != "" {
+		return filepath.Join(state, "showagent", "imports"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("locate import receipt directory: %w", err)
+	}
+	return filepath.Join(home, ".local", "state", "showagent", "imports"), nil
+}

--- a/internal/session/import_receipt.go
+++ b/internal/session/import_receipt.go
@@ -230,7 +230,10 @@ func importJCodeReceiptTarget(cwd, id string) (Row, error) {
 		return Row{}, fmt.Errorf("%w: committed JCode target id is empty", ErrImportVerification)
 	}
 	for _, character := range id {
-		if !(character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' || character >= '0' && character <= '9' || character == '_' || character == '-') {
+		switch {
+		case character >= 'a' && character <= 'z', character >= 'A' && character <= 'Z', character >= '0' && character <= '9', character == '_', character == '-':
+			continue
+		default:
 			return Row{}, fmt.Errorf("%w: committed JCode target id is invalid", ErrImportVerification)
 		}
 	}

--- a/internal/session/import_test.go
+++ b/internal/session/import_test.go
@@ -65,7 +65,11 @@ func TestApplyImportCreatesNativeSessionInSelectedAbsoluteFolder(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if receipt.Row.Provider != ProviderCodex || receipt.Row.ID == "" || receipt.Row.CWD != workspace {
+	resolvedWorkspace, err := filepath.EvalSymlinks(workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Row.Provider != ProviderCodex || receipt.Row.ID == "" || receipt.Row.CWD != resolvedWorkspace {
 		t.Fatalf("created row = %#v", receipt.Row)
 	}
 

--- a/internal/session/import_test.go
+++ b/internal/session/import_test.go
@@ -1,0 +1,285 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestImportCapabilitiesExposeCreateAndProviderSpecificAppend(t *testing.T) {
+	for _, provider := range ProviderOrder() {
+		capability := ImportCapabilities(provider)
+		if !capability.CanCreate {
+			t.Fatalf("%s create capability = false", provider)
+		}
+		if provider == ProviderCodex {
+			if !capability.CanAppendContext || capability.NativeHistoryVisible || !capability.RequiresCLI {
+				t.Fatalf("Codex capability = %#v", capability)
+			}
+			continue
+		}
+		if capability.CanAppendContext || strings.TrimSpace(capability.Reason) == "" {
+			t.Fatalf("%s append capability = %#v", provider, capability)
+		}
+	}
+
+	unknown := ImportCapabilities(Provider("unknown"))
+	if unknown.CanCreate || unknown.CanAppendContext || strings.TrimSpace(unknown.Reason) == "" {
+		t.Fatalf("unknown capability = %#v", unknown)
+	}
+}
+
+func TestApplyImportCreatesNativeSessionInSelectedAbsoluteFolder(t *testing.T) {
+	root := t.TempDir()
+	workspace := filepath.Join(root, "İstanbul project")
+	if err := makeTestDir(workspace); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CODEX_HOME", filepath.Join(root, "codex"))
+	t.Setenv("SHOWAGENT_STATE_DIR", filepath.Join(root, "showagent-state"))
+
+	messages := []ImportMessage{
+		{Role: "user", Text: "Keep spacing:\r\n\r\n```go\r\n\twork()\r\n```"},
+		{Role: "assistant", Text: "Tamam — spacing preserved."},
+	}
+	request := ImportRequest{
+		Mode:     ImportCreate,
+		Provider: ProviderCodex,
+		CWD:      workspace,
+		Messages: messages,
+	}
+	plan, err := PlanImport(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The plan owns an immutable content snapshot rather than retaining the
+	// caller's parser/importer slice.
+	messages[0].Text = "mutated after preview"
+	receipt, err := ApplyImport(context.Background(), plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Row.Provider != ProviderCodex || receipt.Row.ID == "" || receipt.Row.CWD != workspace {
+		t.Fatalf("created row = %#v", receipt.Row)
+	}
+
+	got, err := Transcript(receipt.Row)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []Turn{
+		{Role: "user", Text: "Keep spacing:\n\n```go\n\twork()\n```"},
+		{Role: "assistant", Text: "Tamam — spacing preserved."},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("created transcript = %#v, want %#v", got, want)
+	}
+}
+
+func TestApplyImportCreateIsIdempotentAfterCommittedReceipt(t *testing.T) {
+	root := t.TempDir()
+	workspace := filepath.Join(root, "project")
+	if err := makeTestDir(workspace); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CODEX_HOME", filepath.Join(root, "codex"))
+	t.Setenv("SHOWAGENT_STATE_DIR", filepath.Join(root, "showagent-state"))
+	request := ImportRequest{
+		Mode: ImportCreate, Provider: ProviderCodex, CWD: workspace,
+		Messages: []ImportMessage{{Role: "user", Text: "same imported decision"}},
+	}
+
+	firstPlan, err := PlanImport(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := ApplyImport(context.Background(), firstPlan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondPlan, err := PlanImport(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := ApplyImport(context.Background(), secondPlan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.NoOp != true || second.Row.ID != first.Row.ID {
+		t.Fatalf("second receipt = %#v, want verified no-op for %q", second, first.Row.ID)
+	}
+	rows := codexProvider{}.Discover()
+	if len(rows) != 1 {
+		t.Fatalf("idempotent create wrote %d native sessions", len(rows))
+	}
+	receipts, err := filepath.Glob(filepath.Join(root, "showagent-state", "imports", "*.committed.json"))
+	if err != nil || len(receipts) != 1 {
+		t.Fatalf("committed receipts = %#v, err=%v", receipts, err)
+	}
+	stored, err := os.ReadFile(receipts[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(stored), "same imported decision") || strings.Contains(string(stored), workspace) {
+		t.Fatalf("receipt persisted transcript or project path: %s", stored)
+	}
+}
+
+func TestApplyImportStopsBeforeNativeWriteForPreparedReceipt(t *testing.T) {
+	t.Run("create", func(t *testing.T) {
+		root := t.TempDir()
+		workspace := filepath.Join(root, "project")
+		if err := makeTestDir(workspace); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("CODEX_HOME", filepath.Join(root, "codex"))
+		t.Setenv("SHOWAGENT_STATE_DIR", filepath.Join(root, "showagent-state"))
+
+		plan, err := PlanImport(ImportRequest{
+			Mode: ImportCreate, Provider: ProviderCodex, CWD: workspace,
+			Messages: []ImportMessage{{Role: "user", Text: "must not be written twice"}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if prior, _, err := prepareImportReceipt(plan); err != nil || prior != nil {
+			t.Fatalf("seed prepared receipt: prior=%#v, err=%v", prior, err)
+		}
+
+		writes := 0
+		previousRegistry := registry
+		registry = append([]ProviderImpl(nil), registry...)
+		for index, impl := range registry {
+			if impl.Name() == ProviderCodex {
+				registry[index] = countingImportProvider{ProviderImpl: impl, writes: &writes}
+				break
+			}
+		}
+		defer func() { registry = previousRegistry }()
+
+		_, err = ApplyImport(context.Background(), plan)
+		if !errors.Is(err, ErrImportOutcomeUncertain) {
+			t.Fatalf("ApplyImport error = %v, want ErrImportOutcomeUncertain", err)
+		}
+		if writes != 0 {
+			t.Fatalf("native provider writer called %d times", writes)
+		}
+	})
+
+	t.Run("codex append", func(t *testing.T) {
+		target, original := writeCodexImportTarget(t)
+		plan, err := PlanImport(ImportRequest{
+			Mode: ImportAppendContext, Target: target,
+			Messages: []ImportMessage{{Role: "assistant", Text: "must not be injected twice"}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if prior, _, err := prepareImportReceipt(plan); err != nil || prior != nil {
+			t.Fatalf("seed prepared receipt: prior=%#v, err=%v", prior, err)
+		}
+
+		starts := 0
+		previousCommand := codexAppServerCommand
+		codexAppServerCommand = func(ctx context.Context, cwd string) *exec.Cmd {
+			starts++
+			return previousCommand(ctx, cwd)
+		}
+		defer func() { codexAppServerCommand = previousCommand }()
+
+		_, err = ApplyImport(context.Background(), plan)
+		if !errors.Is(err, ErrImportOutcomeUncertain) {
+			t.Fatalf("ApplyImport error = %v, want ErrImportOutcomeUncertain", err)
+		}
+		if starts != 0 {
+			t.Fatalf("Codex app-server started %d times", starts)
+		}
+		after, err := os.ReadFile(target.File)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(after, original) {
+			t.Fatal("Codex target changed despite prepared-receipt guard")
+		}
+	})
+}
+
+type countingImportProvider struct {
+	ProviderImpl
+	writes *int
+}
+
+func (provider countingImportProvider) WriteConverted(source Row, turns []Turn) (Row, error) {
+	*provider.writes++
+	return provider.ProviderImpl.WriteConverted(source, turns)
+}
+
+func TestPlanImportValidatesMessagesAndCreateFolder(t *testing.T) {
+	workspace := t.TempDir()
+	tests := []struct {
+		name    string
+		request ImportRequest
+		want    string
+	}{
+		{
+			name: "relative folder",
+			request: ImportRequest{Mode: ImportCreate, Provider: ProviderCodex, CWD: ".",
+				Messages: []ImportMessage{{Role: "user", Text: "hello"}}},
+			want: "absolute",
+		},
+		{
+			name: "missing folder",
+			request: ImportRequest{Mode: ImportCreate, Provider: ProviderCodex, CWD: filepath.Join(workspace, "missing"),
+				Messages: []ImportMessage{{Role: "user", Text: "hello"}}},
+			want: "workspace",
+		},
+		{
+			name: "empty text",
+			request: ImportRequest{Mode: ImportCreate, Provider: ProviderCodex, CWD: workspace,
+				Messages: []ImportMessage{{Role: "user", Text: " \r\n\t"}}},
+			want: "empty",
+		},
+		{
+			name: "unassigned role",
+			request: ImportRequest{Mode: ImportCreate, Provider: ProviderCodex, CWD: workspace,
+				Messages: []ImportMessage{{Role: "unassigned", Text: "hello"}}},
+			want: "role",
+		},
+		{
+			name:    "no messages",
+			request: ImportRequest{Mode: ImportCreate, Provider: ProviderCodex, CWD: workspace},
+			want:    "no user or assistant",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := PlanImport(tt.request)
+			if err == nil || !strings.Contains(strings.ToLower(err.Error()), tt.want) {
+				t.Fatalf("PlanImport error = %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestPlanImportRejectsAppendForNonCodexProvider(t *testing.T) {
+	_, err := PlanImport(ImportRequest{
+		Mode: ImportAppendContext,
+		Target: Row{
+			Provider: ProviderClaude,
+			ID:       "exact-id",
+			CWD:      t.TempDir(),
+			File:     filepath.Join(t.TempDir(), "session.jsonl"),
+		},
+		Messages: []ImportMessage{{Role: "user", Text: "hello"}},
+	})
+	if err == nil || !errors.Is(err, ErrImportAppendUnavailable) {
+		t.Fatalf("PlanImport error = %v", err)
+	}
+}

--- a/internal/session/import_test.go
+++ b/internal/session/import_test.go
@@ -2,13 +2,16 @@ package session
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestImportCapabilitiesExposeCreateAndProviderSpecificAppend(t *testing.T) {
@@ -31,6 +34,138 @@ func TestImportCapabilitiesExposeCreateAndProviderSpecificAppend(t *testing.T) {
 	unknown := ImportCapabilities(Provider("unknown"))
 	if unknown.CanCreate || unknown.CanAppendContext || strings.TrimSpace(unknown.Reason) == "" {
 		t.Fatalf("unknown capability = %#v", unknown)
+	}
+}
+
+func TestApplyImportLocalCreateProvidersPreserveContentAndRetry(t *testing.T) {
+	sources := []struct {
+		name     string
+		messages []ImportMessage
+	}{
+		{
+			name: "user and assistant",
+			messages: []ImportMessage{
+				{Role: "user", Text: "Keep this decision — İstanbul.\n```go\n\twork()\n```"},
+				{Role: "assistant", Text: "Yanıt 東京\n  Keep indentation and api_key=local-fixture-value."},
+			},
+		},
+		{
+			name:     "assistant only",
+			messages: []ImportMessage{{Role: "assistant", Text: "Only an answer — 東京\n```text\n  preserved\n```"}},
+		},
+	}
+	for _, provider := range []Provider{ProviderCodex, ProviderClaude, ProviderGemini, ProviderJCode, ProviderPi} {
+		t.Run(string(provider), func(t *testing.T) {
+			for _, source := range sources {
+				t.Run(source.name, func(t *testing.T) {
+					root := t.TempDir()
+					setEmptyHomes(t, root)
+					t.Setenv("SHOWAGENT_STATE_DIR", filepath.Join(root, "state"))
+					t.Setenv("PATH", filepath.Join(root, "empty-bin"))
+					workspace := filepath.Join(root, "project with spaces")
+					if err := os.MkdirAll(workspace, 0o700); err != nil {
+						t.Fatal(err)
+					}
+					plan, err := PlanImport(ImportRequest{Mode: ImportCreate, Provider: provider, CWD: workspace, Messages: source.messages})
+					if err != nil {
+						t.Fatal(err)
+					}
+					first, err := ApplyImport(context.Background(), plan)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if first.Row.ID == "" || first.Row.Provider != provider || !sameImportPath(first.Row.CWD, plan.CWD) {
+						t.Fatalf("native target identity=%#v", first.Row)
+					}
+					before, err := os.ReadFile(first.Row.File)
+					if err != nil {
+						t.Fatal(err)
+					}
+					turns, err := Transcript(first.Row)
+					if err != nil || !reflect.DeepEqual(turns, importTurns(source.messages)) {
+						t.Fatalf("native transcript=%#v, err=%v, want=%#v", turns, err, source.messages)
+					}
+					repeatPlan, err := PlanImport(ImportRequest{Mode: ImportCreate, Provider: provider, CWD: workspace, Messages: source.messages})
+					if err != nil {
+						t.Fatal(err)
+					}
+					second, err := ApplyImport(context.Background(), repeatPlan)
+					if err != nil || !second.NoOp || second.Row.ID != first.Row.ID || !sameImportPath(second.Row.CWD, plan.CWD) {
+						t.Fatalf("native retry=%#v, err=%v", second, err)
+					}
+					after, err := os.ReadFile(second.Row.File)
+					if err != nil || !reflect.DeepEqual(before, after) {
+						t.Fatalf("verified retry changed native bytes, err=%v", err)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestApplyImportOpenCodeCreatePreservesContentAndRetryThroughCLI(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the existing fake OpenCode CLI fixture uses a POSIX shell")
+	}
+	for _, source := range []struct {
+		name     string
+		messages []ImportMessage
+	}{
+		{"user and assistant", []ImportMessage{{Role: "user", Text: "Preserve Unicode — 東京."}, {Role: "assistant", Text: "```go\n\twork()\n```"}}},
+		{"assistant only", []ImportMessage{{Role: "assistant", Text: "An answer without a user preview."}}},
+	} {
+		t.Run(source.name, func(t *testing.T) {
+			root := t.TempDir()
+			setEmptyHomes(t, root)
+			t.Setenv("SHOWAGENT_STATE_DIR", filepath.Join(root, "state"))
+			fixtureDir := opencodeFixtureHome(t)
+			withFakeOpenCode(t, fixtureDir)
+			plan, err := PlanImport(ImportRequest{Mode: ImportCreate, Provider: ProviderOpenCode, CWD: root, Messages: source.messages})
+			if err != nil {
+				t.Fatal(err)
+			}
+			first, err := ApplyImport(context.Background(), plan)
+			if err != nil {
+				t.Fatal(err)
+			}
+			payload, err := os.ReadFile(filepath.Join(fixtureDir, "imported.json"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Serve exactly what the import command received as the CLI's export
+			// and make that new ID discoverable for the subsequent receipt check.
+			if err := os.WriteFile(filepath.Join(fixtureDir, "export.json"), payload, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			sessions, err := json.Marshal([]map[string]any{{"id": first.Row.ID, "directory": plan.CWD, "title": "Imported conversation", "created": time.Now().UnixMilli(), "updated": time.Now().UnixMilli()}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(fixtureDir, "sessions.json"), sessions, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			turns, err := Transcript(first.Row)
+			if err != nil || !reflect.DeepEqual(turns, importTurns(source.messages)) {
+				t.Fatalf("OpenCode exported transcript=%#v, err=%v", turns, err)
+			}
+			second, err := ApplyImport(context.Background(), plan)
+			if err != nil || !second.NoOp || second.Row.ID != first.Row.ID || !sameImportPath(second.Row.CWD, plan.CWD) {
+				t.Fatalf("OpenCode retry=%#v, err=%v", second, err)
+			}
+			calls, err := os.ReadFile(filepath.Join(fixtureDir, "calls.log"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			imports := 0
+			for _, call := range strings.Split(string(calls), "\n") {
+				if strings.HasPrefix(call, "import ") {
+					imports++
+				}
+			}
+			if imports != 1 {
+				t.Fatalf("OpenCode import invoked %d times, want exactly one", imports)
+			}
+		})
 	}
 }
 
@@ -132,6 +267,278 @@ func TestApplyImportCreateIsIdempotentAfterCommittedReceipt(t *testing.T) {
 	}
 	if strings.Contains(string(stored), "same imported decision") || strings.Contains(string(stored), workspace) {
 		t.Fatalf("receipt persisted transcript or project path: %s", stored)
+	}
+}
+
+func TestApplyImportAtomicCreateFailureRemainsRetryable(t *testing.T) {
+	root := t.TempDir()
+	store := filepath.Join(root, "codex")
+	if err := os.MkdirAll(store, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	blockedPath := filepath.Join(store, "sessions")
+	if err := os.WriteFile(blockedPath, []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CODEX_HOME", store)
+	t.Setenv("SHOWAGENT_STATE_DIR", filepath.Join(root, "state"))
+	plan, err := PlanImport(ImportRequest{
+		Mode: ImportCreate, Provider: ProviderCodex, CWD: root,
+		Messages: []ImportMessage{{Role: "user", Text: "retry after repairing the native store"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ApplyImport(context.Background(), plan); !errors.Is(err, errImportNotStarted) {
+		t.Fatalf("blocked native create = %v, want safely retryable failure", err)
+	}
+	receipts, err := filepath.Glob(filepath.Join(root, "state", "imports", "*.json"))
+	if err != nil || len(receipts) != 0 {
+		t.Fatalf("failed atomic creation left receipts=%v, err=%v", receipts, err)
+	}
+	if err := os.Remove(blockedPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ApplyImport(context.Background(), plan); err != nil {
+		t.Fatalf("retry after repairing the native store: %v", err)
+	}
+}
+
+func TestApplyImportCreateRetryVerifiesUnfilteredNativePrefix(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("CODEX_HOME", filepath.Join(root, "codex"))
+	t.Setenv("SHOWAGENT_STATE_DIR", filepath.Join(root, "state"))
+	plan, err := PlanImport(ImportRequest{
+		Mode: ImportCreate, Provider: ProviderCodex, CWD: root,
+		Messages: []ImportMessage{
+			{Role: "user", Text: "# AGENTS.md instructions\nPreserve this imported file example."},
+			{Role: "assistant", Text: "The example is part of our conversation."},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := ApplyImport(context.Background(), plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second, err := ApplyImport(context.Background(), plan); err != nil || !second.NoOp || second.Row.ID != first.Row.ID {
+		t.Fatalf("unchanged instruction-shaped import retry=%#v, err=%v", second, err)
+	}
+	file, err := os.OpenFile(first.Row.File, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, writeErr := file.WriteString("{\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":\"A later turn.\"}]}}\n")
+	closeErr := file.Close()
+	if writeErr != nil || closeErr != nil {
+		t.Fatalf("append later turn: write=%v, close=%v", writeErr, closeErr)
+	}
+	if repeated, err := ApplyImport(context.Background(), plan); err != nil || !repeated.NoOp {
+		t.Fatalf("continued instruction-shaped import retry=%#v, err=%v", repeated, err)
+	}
+	data, err := os.ReadFile(first.Row.File)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = []byte(strings.Replace(string(data), "Preserve this imported file example.", "This original content was replaced.", 1))
+	if err := os.WriteFile(first.Row.File, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ApplyImport(context.Background(), plan); !errors.Is(err, ErrImportVerification) {
+		t.Fatalf("modified original import = %v, want verification failure", err)
+	}
+}
+
+func TestApplyImportCreateRetryRejectsMovedWorkspace(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("CODEX_HOME", filepath.Join(root, "codex"))
+	t.Setenv("SHOWAGENT_STATE_DIR", filepath.Join(root, "state"))
+	plan, err := PlanImport(ImportRequest{
+		Mode: ImportCreate, Provider: ProviderCodex, CWD: root,
+		Messages: []ImportMessage{{Role: "user", Text: "same text, selected workspace"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := ApplyImport(context.Background(), plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.OpenFile(first.Row.File, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Codex's latest turn_context owns its current workspace, even while the
+	// creation prefix remains intact.
+	otherWorkspace := t.TempDir()
+	encoder := json.NewEncoder(file)
+	writeErr := encoder.Encode(map[string]any{"type": "turn_context", "payload": map[string]string{"cwd": otherWorkspace}})
+	closeErr := file.Close()
+	if writeErr != nil || closeErr != nil {
+		t.Fatalf("write changed workspace: write=%v, close=%v", writeErr, closeErr)
+	}
+	if _, err := ApplyImport(context.Background(), plan); !errors.Is(err, ErrImportVerification) || !strings.Contains(err.Error(), "different workspace") {
+		t.Fatalf("moved target retry = %v, want workspace verification failure", err)
+	}
+}
+
+func TestApplyImportJCodeCreateRetryWithoutCLIOrUserPreview(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("JCODE_HOME", filepath.Join(root, "jcode"))
+	t.Setenv("SHOWAGENT_STATE_DIR", filepath.Join(root, "state"))
+	t.Setenv("PATH", filepath.Join(root, "empty-bin"))
+	plan, err := PlanImport(ImportRequest{
+		Mode: ImportCreate, Provider: ProviderJCode, CWD: root,
+		Messages: []ImportMessage{{Role: "assistant", Text: "An imported answer can be the entire conversation."}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := ApplyImport(context.Background(), plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len((jcodeProvider{}).Discover()) != 0 {
+		t.Fatal("fixture should be excluded by ordinary JCode discovery")
+	}
+	second, err := ApplyImport(context.Background(), plan)
+	if err != nil || !second.NoOp || second.Row.ID != first.Row.ID || !sameImportPath(second.Row.CWD, plan.CWD) {
+		t.Fatalf("assistant-only JCode retry without CLI=%#v, err=%v", second, err)
+	}
+	files, err := filepath.Glob(filepath.Join(root, "jcode", "sessions", "*.json"))
+	if err != nil || len(files) != 1 {
+		t.Fatalf("JCode retry created native files=%v, err=%v", files, err)
+	}
+}
+
+func TestJCodeImportReceiptLookupRejectsChangedOrUnsafeTarget(t *testing.T) {
+	for _, scenario := range []string{"missing", "native id", "workspace", "traversal id", "stream id", "outside symlink"} {
+		t.Run(scenario, func(t *testing.T) {
+			root := t.TempDir()
+			t.Setenv("JCODE_HOME", filepath.Join(root, "jcode"))
+			t.Setenv("SHOWAGENT_STATE_DIR", filepath.Join(root, "state"))
+			t.Setenv("PATH", filepath.Join(root, "empty-bin"))
+			plan, err := PlanImport(ImportRequest{
+				Mode: ImportCreate, Provider: ProviderJCode, CWD: root,
+				Messages: []ImportMessage{{Role: "assistant", Text: "A known native session with an exact identity."}},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			first, err := ApplyImport(context.Background(), plan)
+			if err != nil {
+				t.Fatal(err)
+			}
+			id := first.Row.ID
+			switch scenario {
+			case "missing":
+				if err := os.Remove(first.Row.File); err != nil {
+					t.Fatal(err)
+				}
+			case "native id", "workspace":
+				native, ok := readJCodeSession(first.Row.File)
+				if !ok {
+					t.Fatal("could not read fixture")
+				}
+				if scenario == "native id" {
+					native.ID = "another_native_session"
+				} else {
+					native.WorkingDir = t.TempDir()
+				}
+				data, err := json.Marshal(native)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(first.Row.File, data, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			case "traversal id":
+				id = "../" + id
+			case "stream id":
+				id += ":stream"
+			case "outside symlink":
+				outside := filepath.Join(t.TempDir(), filepath.Base(first.Row.File))
+				if err := os.Rename(first.Row.File, outside); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(outside, first.Row.File); err != nil {
+					t.Skipf("file symlinks unavailable: %v", err)
+				}
+			}
+			if _, err := importJCodeReceiptTarget(plan.CWD, id); !errors.Is(err, ErrImportVerification) {
+				t.Fatalf("unsafe or changed target lookup = %v, want verification failure", err)
+			}
+		})
+	}
+}
+
+func TestPlanImportSupportsSymlinkedNativeStore(t *testing.T) {
+	target, _ := writeCodexImportTarget(t)
+	store := filepath.Join(os.Getenv("CODEX_HOME"), "sessions")
+	realStore := filepath.Join(os.Getenv("CODEX_HOME"), "actual-sessions")
+	if err := os.Rename(store, realStore); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realStore, store); err != nil {
+		t.Skipf("directory symlinks unavailable: %v", err)
+	}
+	plan, err := PlanImport(ImportRequest{
+		Mode: ImportAppendContext, Target: target,
+		Messages: []ImportMessage{{Role: "user", Text: "use the configured native store"}},
+	})
+	if err != nil {
+		t.Fatalf("symlinked configured store: %v", err)
+	}
+	if !pathWithin(realStore, plan.Target.File) {
+		t.Fatalf("target was not resolved inside the configured store: %s", plan.Target.File)
+	}
+	outside := filepath.Join(t.TempDir(), "outside.jsonl")
+	data, err := os.ReadFile(plan.Target.File)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(outside, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	target.File = outside
+	if _, err := PlanImport(ImportRequest{Mode: ImportAppendContext, Target: target, Messages: plan.ReviewedMessages}); err == nil {
+		t.Fatal("outside-store session was accepted")
+	}
+}
+
+func TestPlanImportRejectsEscapedRecordsBeyondNativeReaderLimit(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("SHOWAGENT_STATE_DIR", filepath.Join(root, "state"))
+	for _, provider := range []Provider{ProviderCodex, ProviderClaude, ProviderPi, ProviderGemini} {
+		for _, character := range []string{"\"", "\\"} {
+			_, err := PlanImport(ImportRequest{
+				Mode: ImportCreate, Provider: provider, CWD: root,
+				Messages: []ImportMessage{{Role: "user", Text: strings.Repeat(character, 9*1024*1024)}},
+			})
+			if err == nil || !strings.Contains(err.Error(), "native record limit after JSON escaping") {
+				t.Fatalf("%s escaped %q message: %v", provider, character, err)
+			}
+		}
+		if _, err := PlanImport(ImportRequest{
+			Mode: ImportCreate, Provider: provider, CWD: root,
+			Messages: []ImportMessage{{Role: "user", Text: "small \\\"escaped\\\" example"}},
+		}); err != nil {
+			t.Fatalf("%s small escaped message: %v", provider, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(root, "state")); !os.IsNotExist(err) {
+		t.Fatalf("planning wrote receipt state: %v", err)
+	}
+	_, err := PlanImport(ImportRequest{
+		Mode: ImportCreate, Provider: ProviderGemini, CWD: root,
+		Messages: []ImportMessage{
+			{Role: "user", Text: strings.Repeat("\"", 5*1024*1024)},
+			{Role: "assistant", Text: strings.Repeat("\\", 4*1024*1024)},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "import conversation exceeds") {
+		t.Fatalf("Gemini whole conversation record limit: %v", err)
 	}
 }
 

--- a/internal/session/import_test.go
+++ b/internal/session/import_test.go
@@ -210,6 +210,52 @@ func TestApplyImportStopsBeforeNativeWriteForPreparedReceipt(t *testing.T) {
 	})
 }
 
+func TestApplyImportMissingRequiredCLIRemainsRetryable(t *testing.T) {
+	root := t.TempDir()
+	workspace := filepath.Join(root, "project")
+	if err := makeTestDir(workspace); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SHOWAGENT_STATE_DIR", filepath.Join(root, "showagent-state"))
+	t.Setenv("PATH", filepath.Join(root, "empty-bin"))
+
+	plan, err := PlanImport(ImportRequest{
+		Mode: ImportCreate, Provider: ProviderOpenCode, CWD: workspace,
+		Messages: []ImportMessage{{Role: "user", Text: "retry after installing the CLI"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writes := 0
+	previousRegistry := registry
+	registry = append([]ProviderImpl(nil), registry...)
+	for index, impl := range registry {
+		if impl.Name() == ProviderOpenCode {
+			registry[index] = countingImportProvider{ProviderImpl: impl, writes: &writes}
+			break
+		}
+	}
+	defer func() { registry = previousRegistry }()
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		_, err = ApplyImport(context.Background(), plan)
+		if err == nil || !strings.Contains(err.Error(), "opencode not found in PATH") {
+			t.Fatalf("attempt %d error = %v, want missing CLI", attempt, err)
+		}
+		if errors.Is(err, ErrImportOutcomeUncertain) {
+			t.Fatalf("attempt %d became outcome-uncertain before a native write", attempt)
+		}
+	}
+	if writes != 0 {
+		t.Fatalf("native provider writer called %d times", writes)
+	}
+	receipts, err := filepath.Glob(filepath.Join(root, "showagent-state", "imports", "*.json"))
+	if err != nil || len(receipts) != 0 {
+		t.Fatalf("pre-write failure left receipts = %#v, err=%v", receipts, err)
+	}
+}
+
 type countingImportProvider struct {
 	ProviderImpl
 	writes *int

--- a/internal/tui/import.go
+++ b/internal/tui/import.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"unicode/utf8"
 
 	"charm.land/bubbles/v2/textarea"
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/atotto/clipboard"
 
 	"github.com/aytzey/showagent/internal/importer"
 	"github.com/aytzey/showagent/internal/session"
@@ -23,9 +25,10 @@ var (
 	fetchImportLink = func(ctx context.Context, value string) (importer.Conversation, error) {
 		return importer.ImportURL(ctx, value, importer.FetchOptions{})
 	}
-	planSessionImport  = session.PlanImport
-	applySessionImport = session.ApplyImport
-	importWorkingDir   = os.Getwd
+	planSessionImport   = session.PlanImport
+	applySessionImport  = session.ApplyImport
+	importWorkingDir    = os.Getwd
+	readImportClipboard = clipboard.ReadAll
 )
 
 type importStep int
@@ -70,14 +73,22 @@ type importAppliedMsg struct {
 	err     error
 }
 
+type importClipboardMsg struct {
+	text string
+	err  error
+}
+
 type importWizard struct {
 	step          importStep
 	source        importSource
 	destination   importDestinationKind
 	linkInput     textinput.Model
 	pasteInput    textarea.Model
+	pasteOriginal *string
+	pasteHint     string
 	cwdInput      textinput.Model
 	reviewFocused bool
+	applyFocused  bool
 	asNote        bool
 	conversation  importer.Conversation
 	providerIndex int
@@ -98,6 +109,7 @@ func newImportWizard() *importWizard {
 	paste := textarea.New()
 	paste.Placeholder = "User:\nPaste the question here.\n\nAssistant:\nPaste the answer here."
 	paste.ShowLineNumbers = false
+	paste.MaxHeight = 0
 	paste.Prompt = "│ "
 	paste.SetWidth(64)
 	paste.SetHeight(9)
@@ -186,6 +198,12 @@ func (m model) updateImport(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if isImportReviewKey(msg) {
 			return m.startImportParse()
 		}
+		if w.source == importPastedText && (msg.String() == "ctrl+v" || msg.String() == "shift+insert") {
+			return m, func() tea.Msg {
+				text, err := readImportClipboard()
+				return importClipboardMsg{text: text, err: err}
+			}
+		}
 		return m.updateImportInput(msg)
 	case importPreview:
 		switch msg.String() {
@@ -228,7 +246,7 @@ func (m model) updateImport(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				CWD:      w.cwdInput.Value(),
 				Messages: importMessages(w.conversation),
 			})
-		case "b":
+		case "alt+left":
 			w.cwdInput.Blur()
 			w.step = importDestination
 			return m, nil
@@ -266,18 +284,18 @@ func (m model) updateImport(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 	case importReview:
 		switch msg.String() {
+		case "tab", "shift+tab":
+			w.applyFocused = !w.applyFocused
+		case "enter":
+			if w.applyFocused {
+				return m.startImportApply()
+			}
 		case "b":
 			w.plan = session.ImportPlan{}
 			w.step = importDestination
 			w.notice = ""
 		case "ctrl+enter":
-			w.busy = "Applying import"
-			w.notice = ""
-			plan := w.plan
-			return m, func() tea.Msg {
-				receipt, err := applySessionImport(context.Background(), plan)
-				return importAppliedMsg{receipt: receipt, err: err}
-			}
+			return m.startImportApply()
 		}
 	case importSuccess:
 		if msg.String() == "enter" {
@@ -286,6 +304,17 @@ func (m model) updateImport(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 	return m, nil
+}
+
+func (m model) startImportApply() (tea.Model, tea.Cmd) {
+	w := m.importFlow
+	w.busy = "Applying import"
+	w.notice = ""
+	plan := w.plan
+	return m, func() tea.Msg {
+		receipt, err := applySessionImport(context.Background(), plan)
+		return importAppliedMsg{receipt: receipt, err: err}
+	}
 }
 
 func (w *importWizard) focusSourceInput() tea.Cmd {
@@ -297,7 +326,7 @@ func (w *importWizard) focusSourceInput() tea.Cmd {
 
 func (m model) updateImportInput(msg tea.Msg) (tea.Model, tea.Cmd) {
 	w := m.importFlow
-	if w == nil {
+	if w == nil || w.busy != "" || w.reviewFocused {
 		return m, nil
 	}
 	var cmd tea.Cmd
@@ -306,12 +335,67 @@ func (m model) updateImportInput(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if w.source == importShareLink {
 			w.linkInput, cmd = w.linkInput.Update(msg)
 		} else {
+			switch pasted := msg.(type) {
+			case tea.PasteMsg:
+				w.setPastedConversation(pasted.Content)
+				return m, nil
+			case importClipboardMsg:
+				if pasted.err != nil {
+					w.notice = "Clipboard could not be read. Use your terminal's paste action instead."
+				} else {
+					w.setPastedConversation(pasted.text)
+				}
+				return m, nil
+			case tea.KeyPressMsg:
+				if w.pasteOriginal != nil {
+					switch pasted.String() {
+					case "up", "down", "left", "right", "home", "end", "pgup", "pgdown":
+					default:
+						w.notice = "Original formatting is preserved. Edit the source and paste the complete conversation again."
+						return m, nil
+					}
+				}
+			}
 			w.pasteInput, cmd = w.pasteInput.Update(msg)
 		}
 	case importCreateDestination:
 		w.cwdInput, cmd = w.cwdInput.Update(msg)
 	}
 	return m, cmd
+}
+
+// Keep the original whenever the editor would expand tabs, remove characters,
+// or truncate a large paste. A new paste explicitly replaces the source.
+func (w *importWizard) setPastedConversation(text string) {
+	if !utf8.ValidString(text) {
+		w.notice = "Pasted text is not valid UTF-8. The previous source is unchanged."
+		return
+	}
+	text = strings.ReplaceAll(strings.ReplaceAll(text, "\r\n", "\n"), "\r", "\n")
+	if len(text) > importer.MaxTextBytes {
+		w.notice = "Pasted text exceeds the 10 MiB limit. The previous source is unchanged."
+		return
+	}
+	const previewBytes = 8192
+	display := text
+	if len(display) > previewBytes {
+		end := previewBytes
+		for !utf8.RuneStart(display[end]) {
+			end--
+		}
+		display = display[:end]
+	}
+	w.pasteInput.SetValue(display)
+	w.pasteOriginal = nil
+	w.pasteHint = ""
+	w.notice = ""
+	if w.pasteInput.Value() != text {
+		w.pasteOriginal = &text
+		w.pasteHint = "Original formatting preserved. To edit, paste the revised conversation."
+		if len(display) < len(text) {
+			w.pasteHint = fmt.Sprintf("Showing the first 8 KiB; all %d bytes are kept. Paste again to replace.", len(text))
+		}
+	}
 }
 
 func (m model) startImportParse() (tea.Model, tea.Cmd) {
@@ -324,6 +408,9 @@ func (m model) startImportParse() (tea.Model, tea.Cmd) {
 	source := w.source
 	link := strings.TrimSpace(w.linkInput.Value())
 	paste := w.pasteInput.Value()
+	if w.pasteOriginal != nil {
+		paste = *w.pasteOriginal
+	}
 	asNote := w.asNote
 	return m, func() tea.Msg {
 		var conversation importer.Conversation
@@ -379,6 +466,7 @@ func (m model) applyImportPlanned(msg importPlannedMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	w.plan = msg.plan
+	w.applyFocused = false
 	w.notice = ""
 	w.cwdInput.Blur()
 	w.step = importReview
@@ -546,10 +634,15 @@ func (m model) importInputView() []string {
 	if w.asNote {
 		note = "on · imported as one user context message"
 	}
+	editing := "Use explicit User:/Assistant: labels. Plain Enter adds a newline."
+	if w.pasteOriginal != nil {
+		editing = "Use explicit User:/Assistant: labels in the source, or import as one context note."
+	}
 	return append(lines,
 		m.render.theme.workspace.Render("Pasted conversation"),
 		w.pasteInput.View(),
-		m.render.theme.muted.Render("Use explicit User:/Assistant: labels. Plain Enter adds a newline."),
+		m.render.theme.muted.Render(editing),
+		m.render.theme.muted.Render("Pasting replaces the conversation. "+w.pasteHint),
 		m.render.theme.muted.Render("Import as one context note: "+note),
 		"",
 		review,
@@ -568,8 +661,9 @@ func (m model) importPreviewView() []string {
 		m.importField("messages", fmt.Sprintf("%d · text only", len(w.conversation.Messages))),
 	}
 	if w.conversation.Title != "" {
-		lines = append(lines, m.importField("title", session.SafeDisplayText(w.conversation.Title)))
+		lines = append(lines, m.importField("title", session.SafeDisplayText(session.RedactTranscriptText(w.conversation.Title))))
 	}
+	lines = append(lines, m.importSourceWarnings()...)
 	lines = append(lines,
 		m.importField("first", first),
 		m.importField("last", last),
@@ -593,10 +687,18 @@ func (m model) importDestinationView() []string {
 	}
 }
 
+func (m model) importSourceWarnings() []string {
+	conversation := m.importFlow.conversation
+	lines := []string{m.importField("scope", string(conversation.Completeness))}
+	for _, warning := range conversation.Warnings {
+		lines = append(lines, m.importField("omitted", warning.Summary()))
+	}
+	return lines
+}
+
 func (m model) importCreateView() []string {
 	w := m.importFlow
 	provider := w.selectedProvider()
-	capability := session.ImportCapabilities(provider)
 	lines := []string{
 		m.render.theme.title.Render("Import conversation · New session"),
 		"",
@@ -607,10 +709,10 @@ func (m model) importCreateView() []string {
 		w.cwdInput.View(),
 		m.render.theme.muted.Render("The agent works here; conversation data stays in its native session storage."),
 	}
-	if capability.RequiresCLI && !session.ProviderCommandAvailable(provider) {
+	if provider == session.ProviderOpenCode && !session.ProviderCommandAvailable(provider) {
 		lines = append(lines, m.render.theme.muted.Render("Creating this provider's session requires its CLI in PATH."))
 	}
-	return append(lines, "", m.render.theme.hint.Render("enter review destination · tab agent · b back · esc cancel"))
+	return append(lines, "", m.render.theme.hint.Render("enter review destination · tab agent · alt+← back · esc cancel"))
 }
 
 func (m model) importExistingView() []string {
@@ -660,12 +762,18 @@ func (m model) importReviewView() []string {
 		m.importField("session", id),
 		m.importField("content", fmt.Sprintf("%d messages · text only", plan.MessageCount)),
 		"",
-		m.render.theme.muted.Render("This writes history only. It does not resume the agent or start a model response."),
+		m.render.theme.muted.Render("This saves history without launching an interactive agent or starting a model response."),
+	}
+	if plan.Mode == session.ImportAppendContext {
+		lines = append(lines, m.render.theme.muted.Render("Close other clients using this session before importing."))
 	}
 	if plan.Mode == session.ImportAppendContext && !plan.Capability.NativeHistoryVisible {
 		lines = append(lines, m.render.theme.muted.Render("Imported context may not appear as chat bubbles in the target agent."))
 	}
-	return append(lines, "", m.render.theme.hint.Render("ctrl+enter apply import · b back · esc cancel"))
+	lines = append(lines, m.importSourceWarnings()...)
+	return append(lines, "",
+		m.importOption(w.applyFocused, "Apply import", "Save the reviewed conversation to this destination."),
+		"", m.render.theme.hint.Render("tab focus Apply · enter activate · ctrl+enter apply · b back · esc cancel"))
 }
 
 func (m model) importSuccessView() []string {
@@ -697,7 +805,7 @@ func (m model) importSuccessView() []string {
 	}
 	return append(lines,
 		"",
-		m.render.theme.muted.Render("No agent was resumed and no model response was started."),
+		m.render.theme.muted.Render("Saved locally. Resume from the session list when ready."),
 		m.render.theme.hint.Render("enter close · esc close"),
 	)
 }
@@ -734,7 +842,7 @@ func importBoundaries(conversation importer.Conversation) (string, string) {
 		return "(none)", "(none)"
 	}
 	boundary := func(message importer.Message) string {
-		text := strings.Join(strings.Fields(session.SafeDisplayText(message.Text)), " ")
+		text := session.SafeDisplayText(session.RedactTranscriptText(message.Text))
 		return fmt.Sprintf("%s: %s", message.Role, truncateCells(text, 52))
 	}
 	return boundary(conversation.Messages[0]), boundary(conversation.Messages[len(conversation.Messages)-1])

--- a/internal/tui/import.go
+++ b/internal/tui/import.go
@@ -1,0 +1,772 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"charm.land/bubbles/v2/textarea"
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/aytzey/showagent/internal/importer"
+	"github.com/aytzey/showagent/internal/session"
+)
+
+// Function variables keep TUI tests hermetic: link parsing and native writes
+// are exercised through messages without reaching the network or real stores.
+var (
+	parseImportText = importer.ParseText
+	fetchImportLink = func(ctx context.Context, value string) (importer.Conversation, error) {
+		return importer.ImportURL(ctx, value, importer.FetchOptions{})
+	}
+	planSessionImport  = session.PlanImport
+	applySessionImport = session.ApplyImport
+	importWorkingDir   = os.Getwd
+)
+
+type importStep int
+
+const (
+	importChooseSource importStep = iota
+	importEnterSource
+	importPreview
+	importDestination
+	importCreateDestination
+	importExistingDestination
+	importReview
+	importSuccess
+)
+
+type importSource int
+
+const (
+	importShareLink importSource = iota
+	importPastedText
+)
+
+type importDestinationKind int
+
+const (
+	importCreateNew importDestinationKind = iota
+	importAppendExisting
+)
+
+type importParsedMsg struct {
+	conversation importer.Conversation
+	err          error
+}
+
+type importPlannedMsg struct {
+	plan session.ImportPlan
+	err  error
+}
+
+type importAppliedMsg struct {
+	receipt session.ImportReceipt
+	err     error
+}
+
+type importWizard struct {
+	step          importStep
+	source        importSource
+	destination   importDestinationKind
+	linkInput     textinput.Model
+	pasteInput    textarea.Model
+	cwdInput      textinput.Model
+	reviewFocused bool
+	asNote        bool
+	conversation  importer.Conversation
+	providerIndex int
+	existingIndex int
+	plan          session.ImportPlan
+	receipt       session.ImportReceipt
+	busy          string
+	notice        string
+}
+
+func newImportWizard() *importWizard {
+	link := textinput.New()
+	link.Prompt = "> "
+	link.Placeholder = "https://chatgpt.com/share/... or https://claude.ai/share/..."
+	link.CharLimit = 512
+	link.SetWidth(64)
+
+	paste := textarea.New()
+	paste.Placeholder = "User:\nPaste the question here.\n\nAssistant:\nPaste the answer here."
+	paste.ShowLineNumbers = false
+	paste.Prompt = "│ "
+	paste.SetWidth(64)
+	paste.SetHeight(9)
+
+	cwd := textinput.New()
+	cwd.Prompt = "> "
+	cwd.Placeholder = "absolute project folder"
+	cwd.SetWidth(64)
+	if value, err := importWorkingDir(); err == nil {
+		cwd.SetValue(value)
+	}
+
+	return &importWizard{
+		step:       importChooseSource,
+		linkInput:  link,
+		pasteInput: paste,
+		cwdInput:   cwd,
+	}
+}
+
+func (m model) openImport() (tea.Model, tea.Cmd) {
+	m.importFlow = newImportWizard()
+	m.help.ShowAll = false
+	return m, nil
+}
+
+func (m model) updateImport(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	w := m.importFlow
+	if w == nil {
+		return m, nil
+	}
+	if w.busy != "" {
+		return m, nil
+	}
+	if msg.String() == "esc" {
+		m.importFlow = nil
+		return m, nil
+	}
+
+	switch w.step {
+	case importChooseSource:
+		switch msg.String() {
+		case "up", "down", "j", "k", "tab":
+			if w.source == importShareLink {
+				w.source = importPastedText
+			} else {
+				w.source = importShareLink
+			}
+		case "enter":
+			w.step = importEnterSource
+			w.notice = ""
+			if w.source == importShareLink {
+				return m, w.linkInput.Focus()
+			}
+			return m, w.pasteInput.Focus()
+		}
+	case importEnterSource:
+		if w.reviewFocused {
+			switch msg.String() {
+			case "enter":
+				w.reviewFocused = false
+				return m.startImportParse()
+			case "tab", "shift+tab":
+				w.reviewFocused = false
+				return m, w.focusSourceInput()
+			}
+			return m, nil
+		}
+		if msg.String() == "f2" && w.source == importShareLink {
+			w.source = importPastedText
+			w.notice = "Paste the conversation with explicit User:/Assistant: labels."
+			w.linkInput.Blur()
+			return m, w.pasteInput.Focus()
+		}
+		if msg.String() == "ctrl+r" && w.source == importPastedText {
+			w.asNote = !w.asNote
+			w.notice = ""
+			return m, nil
+		}
+		if msg.String() == "tab" {
+			w.reviewFocused = true
+			w.linkInput.Blur()
+			w.pasteInput.Blur()
+			return m, nil
+		}
+		if isImportReviewKey(msg) {
+			return m.startImportParse()
+		}
+		return m.updateImportInput(msg)
+	case importPreview:
+		switch msg.String() {
+		case "enter":
+			w.step = importDestination
+			w.notice = ""
+		case "b":
+			w.step = importEnterSource
+			w.reviewFocused = false
+			w.notice = ""
+			return m, w.focusSourceInput()
+		}
+	case importDestination:
+		switch msg.String() {
+		case "up", "down", "j", "k", "tab":
+			if w.destination == importCreateNew {
+				w.destination = importAppendExisting
+			} else {
+				w.destination = importCreateNew
+			}
+		case "enter":
+			w.notice = ""
+			if w.destination == importCreateNew {
+				w.step = importCreateDestination
+				return m, w.cwdInput.Focus()
+			}
+			w.step = importExistingDestination
+			w.existingIndex = 0
+		}
+	case importCreateDestination:
+		switch msg.String() {
+		case "tab":
+			w.providerIndex = nextImportProviderIndex(w.providerIndex)
+			w.notice = ""
+			return m, nil
+		case "enter", "ctrl+enter":
+			return m.startImportPlan(session.ImportRequest{
+				Mode:     session.ImportCreate,
+				Provider: w.selectedProvider(),
+				CWD:      w.cwdInput.Value(),
+				Messages: importMessages(w.conversation),
+			})
+		case "b":
+			w.cwdInput.Blur()
+			w.step = importDestination
+			return m, nil
+		}
+		var cmd tea.Cmd
+		w.cwdInput, cmd = w.cwdInput.Update(msg)
+		return m, cmd
+	case importExistingDestination:
+		switch msg.String() {
+		case "up", "k":
+			w.moveExisting(-1, len(m.allRows))
+			w.notice = ""
+		case "down", "j":
+			w.moveExisting(1, len(m.allRows))
+			w.notice = ""
+		case "b":
+			w.step = importDestination
+			w.notice = ""
+		case "enter":
+			if len(m.allRows) == 0 {
+				w.notice = "No existing session is available. Choose Create a new session."
+				return m, nil
+			}
+			row := m.allRows[w.existingIndex]
+			capability := importAppendCapability(row)
+			if !capability.CanAppendContext {
+				w.notice = capability.Reason
+				return m, nil
+			}
+			return m.startImportPlan(session.ImportRequest{
+				Mode:     session.ImportAppendContext,
+				Target:   row,
+				Messages: importMessages(w.conversation),
+			})
+		}
+	case importReview:
+		switch msg.String() {
+		case "b":
+			w.plan = session.ImportPlan{}
+			w.step = importDestination
+			w.notice = ""
+		case "ctrl+enter":
+			w.busy = "Applying import"
+			w.notice = ""
+			plan := w.plan
+			return m, func() tea.Msg {
+				receipt, err := applySessionImport(context.Background(), plan)
+				return importAppliedMsg{receipt: receipt, err: err}
+			}
+		}
+	case importSuccess:
+		if msg.String() == "enter" {
+			m.importFlow = nil
+			return m, nil
+		}
+	}
+	return m, nil
+}
+
+func (w *importWizard) focusSourceInput() tea.Cmd {
+	if w.source == importShareLink {
+		return w.linkInput.Focus()
+	}
+	return w.pasteInput.Focus()
+}
+
+func (m model) updateImportInput(msg tea.Msg) (tea.Model, tea.Cmd) {
+	w := m.importFlow
+	if w == nil {
+		return m, nil
+	}
+	var cmd tea.Cmd
+	switch w.step {
+	case importEnterSource:
+		if w.source == importShareLink {
+			w.linkInput, cmd = w.linkInput.Update(msg)
+		} else {
+			w.pasteInput, cmd = w.pasteInput.Update(msg)
+		}
+	case importCreateDestination:
+		w.cwdInput, cmd = w.cwdInput.Update(msg)
+	}
+	return m, cmd
+}
+
+func (m model) startImportParse() (tea.Model, tea.Cmd) {
+	w := m.importFlow
+	if w == nil {
+		return m, nil
+	}
+	w.busy = "Reviewing conversation"
+	w.notice = ""
+	source := w.source
+	link := strings.TrimSpace(w.linkInput.Value())
+	paste := w.pasteInput.Value()
+	asNote := w.asNote
+	return m, func() tea.Msg {
+		var conversation importer.Conversation
+		var err error
+		if source == importShareLink {
+			conversation, err = fetchImportLink(context.Background(), link)
+		} else {
+			conversation, err = parseImportText(paste, importer.TextOptions{AsOneContextNote: asNote})
+		}
+		return importParsedMsg{conversation: conversation, err: err}
+	}
+}
+
+func (m model) applyImportParsed(msg importParsedMsg) (tea.Model, tea.Cmd) {
+	w := m.importFlow
+	if w == nil {
+		return m, nil
+	}
+	w.busy = ""
+	if msg.err != nil {
+		w.notice = importParseError(w.source, msg.err)
+		return m, nil
+	}
+	w.conversation = msg.conversation
+	w.notice = ""
+	w.linkInput.Blur()
+	w.pasteInput.Blur()
+	w.step = importPreview
+	return m, nil
+}
+
+func (m model) startImportPlan(request session.ImportRequest) (tea.Model, tea.Cmd) {
+	w := m.importFlow
+	if w == nil {
+		return m, nil
+	}
+	w.busy = "Checking destination"
+	w.notice = ""
+	return m, func() tea.Msg {
+		plan, err := planSessionImport(request)
+		return importPlannedMsg{plan: plan, err: err}
+	}
+}
+
+func (m model) applyImportPlanned(msg importPlannedMsg) (tea.Model, tea.Cmd) {
+	w := m.importFlow
+	if w == nil {
+		return m, nil
+	}
+	w.busy = ""
+	if msg.err != nil {
+		w.notice = "Destination cannot be used: " + session.SafeDisplayText(msg.err.Error())
+		return m, nil
+	}
+	w.plan = msg.plan
+	w.notice = ""
+	w.cwdInput.Blur()
+	w.step = importReview
+	return m, nil
+}
+
+func (m model) applyImportApplied(msg importAppliedMsg) (tea.Model, tea.Cmd) {
+	w := m.importFlow
+	if w == nil {
+		return m, nil
+	}
+	w.busy = ""
+	if msg.err != nil {
+		w.plan = session.ImportPlan{}
+		w.step = importDestination
+		w.notice = "Import failed: " + session.SafeDisplayText(msg.err.Error()) + ". Review the destination and try again."
+		return m, nil
+	}
+	w.receipt = msg.receipt
+	w.step = importSuccess
+	w.notice = ""
+
+	row := msg.receipt.Row
+	if row.ID != "" {
+		m.providers[row.Provider] = true
+		delete(m.collapsedGroups, row.CWD)
+		m.allRows = upsertAndSortRows(m.allRows, row)
+		m.list.ResetFilter()
+		cmd := m.list.SetItems(m.currentItems())
+		selectRowItem(&m.list, row)
+		return m, cmd
+	}
+	return m, nil
+}
+
+func isImportReviewKey(msg tea.KeyPressMsg) bool {
+	return msg.String() == "ctrl+enter"
+}
+
+func nextImportProviderIndex(current int) int {
+	providers := creatableImportProviders()
+	if len(providers) == 0 {
+		return 0
+	}
+	return (current + 1) % len(providers)
+}
+
+func creatableImportProviders() []session.Provider {
+	providers := make([]session.Provider, 0, len(session.ProviderOrder()))
+	for _, provider := range session.ProviderOrder() {
+		if session.ImportCapabilities(provider).CanCreate {
+			providers = append(providers, provider)
+		}
+	}
+	return providers
+}
+
+func (w *importWizard) selectedProvider() session.Provider {
+	providers := creatableImportProviders()
+	if len(providers) == 0 {
+		return ""
+	}
+	if w.providerIndex < 0 || w.providerIndex >= len(providers) {
+		w.providerIndex = 0
+	}
+	return providers[w.providerIndex]
+}
+
+func (w *importWizard) moveExisting(delta, count int) {
+	if count <= 0 {
+		w.existingIndex = 0
+		return
+	}
+	w.existingIndex = (w.existingIndex + delta + count) % count
+}
+
+func importMessages(conversation importer.Conversation) []session.ImportMessage {
+	messages := make([]session.ImportMessage, 0, len(conversation.Messages))
+	for _, message := range conversation.Messages {
+		messages = append(messages, session.ImportMessage{Role: string(message.Role), Text: message.Text})
+	}
+	return messages
+}
+
+func importParseError(source importSource, err error) string {
+	var ambiguity *importer.AmbiguityError
+	if errors.As(err, &ambiguity) {
+		return "Some text has no speaker. Add explicit User:/Assistant: labels, or press ctrl+r to import as one context note."
+	}
+	if source == importShareLink {
+		if errors.Is(err, importer.ErrUnsupportedURL) {
+			return "This is not a supported conversation share link. Press F2 to paste the conversation text instead."
+		}
+		if errors.Is(err, importer.ErrConversationUnidentifiable) {
+			return "The page opened, but its conversation could not be identified. Press F2 to paste the text instead."
+		}
+		return "This link could not be read. It may need access or be unavailable. Press F2 to paste the text you can access."
+	}
+	return "Conversation could not be reviewed: " + session.SafeDisplayText(err.Error())
+}
+
+func (m model) importView() string {
+	w := m.importFlow
+	if w == nil {
+		return ""
+	}
+	var lines []string
+	switch w.step {
+	case importChooseSource:
+		lines = m.importSourceView()
+	case importEnterSource:
+		lines = m.importInputView()
+	case importPreview:
+		lines = m.importPreviewView()
+	case importDestination:
+		lines = m.importDestinationView()
+	case importCreateDestination:
+		lines = m.importCreateView()
+	case importExistingDestination:
+		lines = m.importExistingView()
+	case importReview:
+		lines = m.importReviewView()
+	case importSuccess:
+		lines = m.importSuccessView()
+	}
+	if w.busy != "" {
+		lines = append(lines, "", m.render.theme.muted.Render(m.spinner.View()+" "+w.busy+"…"))
+	}
+	if w.notice != "" {
+		lines = append(lines, "", m.render.theme.deleteBanner.Render(w.notice))
+	}
+	return m.centerImportBox(lines)
+}
+
+func (m model) importSourceView() []string {
+	w := m.importFlow
+	return []string{
+		m.render.theme.title.Render("Import conversation"),
+		"",
+		m.importOption(w.source == importShareLink, "Share link", "Read an accessible ChatGPT or Claude share link."),
+		"",
+		m.importOption(w.source == importPastedText, "Paste text", "Process the conversation locally without publishing it."),
+		"",
+		m.render.theme.hint.Render("↑/↓ choose · enter continue · esc cancel"),
+	}
+}
+
+func (m model) importInputView() []string {
+	w := m.importFlow
+	lines := []string{m.render.theme.title.Render("Import conversation · Source"), ""}
+	review := m.importOption(w.reviewFocused, "Review conversation", "Parse and preview the text before choosing a destination.")
+	if w.source == importShareLink {
+		lines = append(lines,
+			m.render.theme.workspace.Render("ChatGPT or Claude share link"),
+			w.linkInput.View(),
+			m.render.theme.muted.Render("Prefer pasted text if you do not want to share the conversation publicly."),
+			"",
+			review,
+			"",
+			m.render.theme.hint.Render("tab focus Review · ctrl+enter review · F2 paste fallback · esc cancel"),
+		)
+		return lines
+	}
+	note := "off"
+	if w.asNote {
+		note = "on · imported as one user context message"
+	}
+	return append(lines,
+		m.render.theme.workspace.Render("Pasted conversation"),
+		w.pasteInput.View(),
+		m.render.theme.muted.Render("Use explicit User:/Assistant: labels. Plain Enter adds a newline."),
+		m.render.theme.muted.Render("Import as one context note: "+note),
+		"",
+		review,
+		"",
+		m.render.theme.hint.Render("tab focus Review · ctrl+enter review · ctrl+r toggle one context note · esc cancel"),
+	)
+}
+
+func (m model) importPreviewView() []string {
+	w := m.importFlow
+	first, last := importBoundaries(w.conversation)
+	lines := []string{
+		m.render.theme.title.Render("Import conversation · Preview"),
+		"",
+		m.importField("source", importSourceLabel(w.conversation.SourceKind)),
+		m.importField("messages", fmt.Sprintf("%d · text only", len(w.conversation.Messages))),
+	}
+	if w.conversation.Title != "" {
+		lines = append(lines, m.importField("title", session.SafeDisplayText(w.conversation.Title)))
+	}
+	lines = append(lines,
+		m.importField("first", first),
+		m.importField("last", last),
+		"",
+		m.render.theme.muted.Render("Attachments, tool state, permissions, and files are not imported."),
+		m.render.theme.hint.Render("enter choose destination · b edit source · esc cancel"),
+	)
+	return lines
+}
+
+func (m model) importDestinationView() []string {
+	w := m.importFlow
+	return []string{
+		m.render.theme.title.Render("Import conversation · Destination"),
+		"",
+		m.importOption(w.destination == importCreateNew, "Create a new session", "Choose an agent and an absolute project folder."),
+		"",
+		m.importOption(w.destination == importAppendExisting, "Add context to an existing session", "Choose one exact session row; support is provider-specific."),
+		"",
+		m.render.theme.hint.Render("↑/↓ choose · enter continue · esc cancel"),
+	}
+}
+
+func (m model) importCreateView() []string {
+	w := m.importFlow
+	provider := w.selectedProvider()
+	capability := session.ImportCapabilities(provider)
+	lines := []string{
+		m.render.theme.title.Render("Import conversation · New session"),
+		"",
+		m.importField("agent", session.DisplayName(provider)),
+		m.render.theme.muted.Render("tab cycles the target agent"),
+		"",
+		m.render.theme.workspace.Render("Project folder"),
+		w.cwdInput.View(),
+		m.render.theme.muted.Render("The agent works here; conversation data stays in its native session storage."),
+	}
+	if capability.RequiresCLI && !session.ProviderCommandAvailable(provider) {
+		lines = append(lines, m.render.theme.muted.Render("Creating this provider's session requires its CLI in PATH."))
+	}
+	return append(lines, "", m.render.theme.hint.Render("enter review destination · tab agent · b back · esc cancel"))
+}
+
+func (m model) importExistingView() []string {
+	w := m.importFlow
+	lines := []string{m.render.theme.title.Render("Import conversation · Existing session"), ""}
+	if len(m.allRows) == 0 {
+		return append(lines,
+			m.render.theme.muted.Render("No existing sessions are available."),
+			"",
+			m.render.theme.hint.Render("b choose Create a new session · esc cancel"),
+		)
+	}
+	start := max(0, w.existingIndex-2)
+	end := min(len(m.allRows), start+5)
+	for index := start; index < end; index++ {
+		row := m.allRows[index]
+		label := fmt.Sprintf("%s · %s · %s", session.DisplayName(row.Provider), session.SafeDisplayText(row.ID), collapseHome(session.SafeDisplayText(row.CWD)))
+		lines = append(lines, m.importOption(index == w.existingIndex, label, importRowPreview(row)))
+	}
+	selected := m.allRows[w.existingIndex]
+	capability := importAppendCapability(selected)
+	lines = append(lines, "", m.importField("exact id", session.SafeDisplayText(selected.ID)))
+	if capability.CanAppendContext {
+		lines = append(lines, m.render.theme.muted.Render("Messages are added to this session's context; they may not appear as chat bubbles."))
+	} else {
+		lines = append(lines, m.render.theme.deleteBanner.Render(capability.Reason))
+	}
+	return append(lines, "", m.render.theme.hint.Render("↑/↓ exact row · enter review · b back · esc cancel"))
+}
+
+func (m model) importReviewView() []string {
+	w := m.importFlow
+	plan := w.plan
+	operation := "Create a new " + session.DisplayName(plan.Provider) + " session"
+	id := "new ID"
+	if plan.Mode == session.ImportAppendContext {
+		operation = fmt.Sprintf("Add %d messages to this session's context", plan.MessageCount)
+		id = session.SafeDisplayText(plan.Target.ID) + " (preserved)"
+	}
+	lines := []string{
+		m.render.theme.title.Render("Import conversation · Final review"),
+		"",
+		m.importField("source", importSourceLabel(w.conversation.SourceKind)),
+		m.importField("operation", operation),
+		m.importField("agent", session.DisplayName(plan.Provider)),
+		m.importField("project", collapseHome(session.SafeDisplayText(plan.CWD))),
+		m.importField("session", id),
+		m.importField("content", fmt.Sprintf("%d messages · text only", plan.MessageCount)),
+		"",
+		m.render.theme.muted.Render("This writes history only. It does not resume the agent or start a model response."),
+	}
+	if plan.Mode == session.ImportAppendContext && !plan.Capability.NativeHistoryVisible {
+		lines = append(lines, m.render.theme.muted.Render("Imported context may not appear as chat bubbles in the target agent."))
+	}
+	return append(lines, "", m.render.theme.hint.Render("ctrl+enter apply import · b back · esc cancel"))
+}
+
+func (m model) importSuccessView() []string {
+	receipt := m.importFlow.receipt
+	verb := "Created"
+	idNote := "new ID"
+	if receipt.NoOp {
+		verb = "Already imported into"
+		idNote = "existing receipt"
+	}
+	if receipt.Mode == session.ImportAppendContext {
+		verb = "Added context to"
+		idNote = "preserved ID"
+		if receipt.NoOp {
+			verb = "Context already present in"
+			idNote = "preserved ID"
+		}
+	}
+	lines := []string{
+		m.render.theme.title.Render("Import complete"),
+		"",
+		m.render.theme.workspace.Render(fmt.Sprintf("%s %s session", verb, session.DisplayName(receipt.Provider))),
+		m.importField("session", session.SafeDisplayText(receipt.Row.ID)+" ("+idNote+")"),
+		m.importField("project", collapseHome(session.SafeDisplayText(receipt.Row.CWD))),
+		m.importField("content", fmt.Sprintf("%d messages", receipt.MessageCount)),
+	}
+	if receipt.Mode == session.ImportAppendContext && !receipt.NativeHistoryVisible {
+		lines = append(lines, "", m.render.theme.muted.Render("Imported context may not appear as chat bubbles in the target agent."))
+	}
+	return append(lines,
+		"",
+		m.render.theme.muted.Render("No agent was resumed and no model response was started."),
+		m.render.theme.hint.Render("enter close · esc close"),
+	)
+}
+
+func (m model) importOption(selected bool, label, description string) string {
+	cursor := "  "
+	style := m.render.theme.muted
+	if selected {
+		cursor = "❯ "
+		style = m.render.theme.workspace
+	}
+	return m.render.theme.cursor.Render(cursor) + style.Render(label) + "\n  " + m.render.theme.muted.Render(description)
+}
+
+func (m model) importField(label, value string) string {
+	return m.render.theme.label.Render(padLabel(label)) + value
+}
+
+func importSourceLabel(kind importer.SourceKind) string {
+	switch kind {
+	case importer.SourceChatGPTShare:
+		return "ChatGPT share link"
+	case importer.SourceClaudeShare:
+		return "Claude share link"
+	case importer.SourcePastedText:
+		return "pasted text"
+	default:
+		return "conversation text"
+	}
+}
+
+func importBoundaries(conversation importer.Conversation) (string, string) {
+	if len(conversation.Messages) == 0 {
+		return "(none)", "(none)"
+	}
+	boundary := func(message importer.Message) string {
+		text := strings.Join(strings.Fields(session.SafeDisplayText(message.Text)), " ")
+		return fmt.Sprintf("%s: %s", message.Role, truncateCells(text, 52))
+	}
+	return boundary(conversation.Messages[0]), boundary(conversation.Messages[len(conversation.Messages)-1])
+}
+
+func importRowPreview(row session.Row) string {
+	preview := strings.Join(strings.Fields(session.SafeDisplayText(bestLast(row))), " ")
+	return truncateCells(preview, 60)
+}
+
+func importAppendCapability(row session.Row) session.ImportCapability {
+	capability := session.ImportCapabilities(row.Provider)
+	if row.HandoffOnly {
+		capability.CanAppendContext = false
+		capability.Reason = "This row is a handoff-only copy, not a native session that Codex can update."
+	}
+	return capability
+}
+
+func (m model) centerImportBox(lines []string) string {
+	boxWidth := 72
+	if m.width > 0 {
+		boxWidth = max(1, min(m.width, boxWidth))
+	}
+	frameW, _ := m.render.theme.detail.GetFrameSize()
+	innerWidth := max(1, boxWidth-frameW)
+	for index := range lines {
+		lines[index] = clampLineWidths(lines[index], innerWidth)
+	}
+	box := m.render.theme.detail.Width(boxWidth).Render(strings.Join(lines, "\n"))
+	if m.width <= 0 || m.height <= 0 {
+		return box
+	}
+	return clampLineWidths(lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box), m.width)
+}

--- a/internal/tui/import_test.go
+++ b/internal/tui/import_test.go
@@ -249,6 +249,14 @@ func TestBusyImportCannotBeDismissedBeforeItsResult(t *testing.T) {
 	if m.importFlow == nil || m.importFlow.busy == "" {
 		t.Fatal("Escape hid an import while its native write was still running")
 	}
+
+	_, quitCmd := m.Update(tea.KeyPressMsg(tea.Key{Code: 'c', Mod: tea.ModCtrl}))
+	if quitCmd == nil {
+		t.Fatal("Ctrl+C did not quit a busy import wizard")
+	}
+	if _, ok := quitCmd().(tea.QuitMsg); !ok {
+		t.Fatalf("Ctrl+C produced %#v, want tea.QuitMsg", quitCmd())
+	}
 }
 
 func ctrlEnter() tea.KeyPressMsg {

--- a/internal/tui/import_test.go
+++ b/internal/tui/import_test.go
@@ -119,6 +119,111 @@ func TestPastedTextTabFocusesVisibleReviewAction(t *testing.T) {
 	}
 }
 
+func TestImportPasteEventsPreserveSource(t *testing.T) {
+	previous := parseImportText
+	t.Cleanup(func() { parseImportText = previous })
+	for _, test := range []struct {
+		name      string
+		input     string
+		want      string
+		protected bool
+	}{
+		{"tabs in code", "User:\n```go\n\treturn 1\n```", "User:\n```go\n\treturn 1\n```", true},
+		{"windows lines", "User:\r\nquestion\r\nAssistant:\r\nanswer", "User:\nquestion\nAssistant:\nanswer", false},
+		{"many lines", "User:\n" + strings.Repeat("line\n", 10001), "User:\n" + strings.Repeat("line\n", 10001), true},
+		{"unicode replacement character", "User:\nvalid \uFFFD", "User:\nvalid \uFFFD", true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var parsed string
+			parseImportText = func(value string, _ importer.TextOptions) (importer.Conversation, error) {
+				parsed = value
+				return importer.Conversation{}, nil
+			}
+			m := openPasteImport(t, sizedModel(nil))
+			next, _ := m.Update(tea.PasteMsg{Content: test.input})
+			m = asModel(t, next)
+			if (m.importFlow.pasteOriginal != nil) != test.protected {
+				t.Fatalf("protected=%v want %v", m.importFlow.pasteOriginal != nil, test.protected)
+			}
+			if test.protected {
+				before := m.importFlow.pasteInput.Value()
+				next, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: 'x', Text: "x"}))
+				m = asModel(t, next)
+				if m.importFlow.pasteInput.Value() != before || !strings.Contains(m.importFlow.notice, "paste") {
+					t.Fatal("editing a protected paste silently changed the source")
+				}
+			}
+			_, cmd := m.Update(ctrlEnter())
+			if cmd == nil {
+				t.Fatal("review did not start")
+			}
+			cmd()
+			if parsed != test.want {
+				t.Fatalf("paste changed: got %d bytes, want %d", len(parsed), len(test.want))
+			}
+		})
+	}
+}
+
+func TestImportPasteReplacementAndRejectedInput(t *testing.T) {
+	m := openPasteImport(t, sizedModel(nil))
+	for _, text := range []string{"User:\n\told", "User:\nreplacement"} {
+		next, _ := m.Update(tea.PasteMsg{Content: text})
+		m = asModel(t, next)
+	}
+	if m.importFlow.pasteOriginal != nil || m.importFlow.pasteInput.Value() != "User:\nreplacement" {
+		t.Fatal("second paste did not replace original snapshot")
+	}
+	for _, text := range []string{string([]byte{0xff}), strings.Repeat("a", importer.MaxTextBytes+1)} {
+		next, _ := m.Update(tea.PasteMsg{Content: text})
+		m = asModel(t, next)
+		if m.importFlow.pasteInput.Value() != "User:\nreplacement" || !strings.Contains(m.importFlow.notice, "unchanged") {
+			t.Fatal("invalid paste overwrote accepted source")
+		}
+	}
+	for _, state := range []string{"busy", "review"} {
+		m.importFlow.busy = ""
+		m.importFlow.reviewFocused = false
+		if state == "busy" {
+			m.importFlow.busy = "Reviewing"
+		} else {
+			m.importFlow.reviewFocused = true
+		}
+		next, _ := m.Update(tea.PasteMsg{Content: "User:\nlate paste"})
+		m = asModel(t, next)
+		if m.importFlow.pasteInput.Value() != "User:\nreplacement" {
+			t.Fatal("late paste changed reviewed source")
+		}
+	}
+}
+
+func TestImportClipboardPreservesTabsAndHandlesFailure(t *testing.T) {
+	previous := readImportClipboard
+	t.Cleanup(func() { readImportClipboard = previous })
+	readImportClipboard = func() (string, error) { return "User:\n\tclipboard", nil }
+	m := openPasteImport(t, sizedModel(nil))
+	next, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: 'v', Mod: tea.ModCtrl}))
+	m = asModel(t, next)
+	if cmd == nil {
+		t.Fatal("clipboard read did not start")
+	}
+	next, _ = m.Update(cmd())
+	m = asModel(t, next)
+	if m.importFlow.pasteOriginal == nil || *m.importFlow.pasteOriginal != "User:\n\tclipboard" {
+		t.Fatal("clipboard formatting changed")
+	}
+	readImportClipboard = func() (string, error) { return "", errors.New("unavailable") }
+	_, cmd = m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyInsert, Mod: tea.ModShift}))
+	if cmd == nil {
+		t.Fatal("shift+insert did not read clipboard")
+	}
+	next, _ = m.Update(cmd())
+	m = asModel(t, next)
+	if !strings.Contains(m.importFlow.notice, "Clipboard could not be read") {
+		t.Fatal("clipboard failure hidden")
+	}
+}
+
 func TestAmbiguousPasteRequiresLabelsOrVisibleOneNoteToggle(t *testing.T) {
 	previous := parseImportText
 	t.Cleanup(func() { parseImportText = previous })
@@ -261,6 +366,64 @@ func TestBusyImportCannotBeDismissedBeforeItsResult(t *testing.T) {
 
 func ctrlEnter() tea.KeyPressMsg {
 	return tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter, Mod: tea.ModCtrl})
+}
+
+func TestImportProjectFolderOwnsLetterKeys(t *testing.T) {
+	m := sizedModel(nil)
+	m.importFlow = newImportWizard()
+	m.importFlow.step = importCreateDestination
+	m.importFlow.cwdInput.SetValue("/tmp/we")
+	m.importFlow.cwdInput.Focus()
+	updated, _ := m.Update(tea.KeyPressMsg(tea.Key{Code: 'b', Text: "b"}))
+	m = asModel(t, updated)
+	if m.importFlow.step != importCreateDestination || m.importFlow.cwdInput.Value() != "/tmp/web" {
+		t.Fatalf("typing a folder navigated away: step=%v folder=%q", m.importFlow.step, m.importFlow.cwdInput.Value())
+	}
+}
+
+func TestImportFinalReviewHasPortableApplyAction(t *testing.T) {
+	previous := applySessionImport
+	t.Cleanup(func() { applySessionImport = previous })
+	applications := 0
+	applySessionImport = func(_ context.Context, _ session.ImportPlan) (session.ImportReceipt, error) {
+		applications++
+		return session.ImportReceipt{}, nil
+	}
+	m := sizedModel(nil)
+	m.importFlow = reviewWizard(session.ImportCreate)
+	unchanged, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	m = asModel(t, unchanged)
+	if cmd != nil || applications != 0 {
+		t.Fatal("enter wrote before focusing the final Apply action")
+	}
+	focused, _ := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyTab}))
+	m = asModel(t, focused)
+	if !m.importFlow.applyFocused || !strings.Contains(m.importView(), "Apply import") {
+		t.Fatal("final review has no focusable Apply action")
+	}
+	_, cmd = m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	if cmd == nil {
+		t.Fatal("enter on Apply did not start import")
+	}
+	cmd()
+	if applications != 1 {
+		t.Fatalf("applications = %d", applications)
+	}
+}
+
+func TestImportPreviewRedactsBoundariesAndShowsSourceLosses(t *testing.T) {
+	m := sizedModel(nil)
+	m.importFlow = previewWizard()
+	m.importFlow.conversation.Messages = []importer.Message{{Role: importer.RoleUser, Text: "password=example-secret"}}
+	m.importFlow.conversation.Completeness = importer.CompletenessVisiblePath
+	m.importFlow.conversation.Warnings = []importer.Warning{{Code: "omitted_non_text_content", Count: 2}}
+	view := m.importView()
+	if strings.Contains(view, "example-secret") || !strings.Contains(view, "[redacted]") {
+		t.Fatalf("unsafe preview: %s", view)
+	}
+	if !strings.Contains(view, "2 non-text content blocks omitted") || !strings.Contains(view, "visible_path") {
+		t.Fatalf("source losses were hidden: %s", view)
+	}
 }
 
 func openPasteImport(t *testing.T, m model) model {

--- a/internal/tui/import_test.go
+++ b/internal/tui/import_test.go
@@ -1,0 +1,291 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/aytzey/showagent/internal/importer"
+	"github.com/aytzey/showagent/internal/session"
+)
+
+func TestEmptyViewOffersConversationImport(t *testing.T) {
+	view := sizedModel(nil).emptyView()
+	if !strings.Contains(view, "i") || !strings.Contains(view, "Import conversation") {
+		t.Fatalf("empty view does not offer import:\n%s", view)
+	}
+}
+
+func TestImportKeyOpensModalWithZeroRowsAndIsolatesListKeys(t *testing.T) {
+	m := sizedModel(nil)
+	opened, _ := m.Update(tea.KeyPressMsg(tea.Key{Code: 'i'}))
+	modal := asModel(t, opened)
+	if view := modal.View().Content; !strings.Contains(view, "Import conversation") || !strings.Contains(view, "Share link") {
+		t.Fatalf("i did not open the import modal:\n%s", view)
+	}
+
+	// Slash belongs to the modal while it is open; it must not activate the
+	// session list's search field behind the overlay.
+	afterSlash, _ := modal.Update(tea.KeyPressMsg(tea.Key{Code: '/'}))
+	isolated := asModel(t, afterSlash)
+	if isolated.list.SettingFilter() {
+		t.Fatal("list search activated behind import modal")
+	}
+	if view := isolated.View().Content; !strings.Contains(view, "Import conversation") {
+		t.Fatalf("modal closed after unrelated list key:\n%s", view)
+	}
+}
+
+func TestHelpIncludesConversationImport(t *testing.T) {
+	view := sizedModel(nil).helpView()
+	if !strings.Contains(view, "import") {
+		t.Fatalf("help does not include import action:\n%s", view)
+	}
+}
+
+func TestPastedTextKeepsNewlinesAndCtrlEnterReviews(t *testing.T) {
+	previous := parseImportText
+	t.Cleanup(func() { parseImportText = previous })
+
+	var parsed string
+	parseImportText = func(value string, options importer.TextOptions) (importer.Conversation, error) {
+		parsed = value
+		return importer.Conversation{
+			SourceKind: importer.SourcePastedText,
+			Messages: []importer.Message{
+				{Role: importer.RoleUser, Text: "question"},
+				{Role: importer.RoleAssistant, Text: "answer"},
+			},
+		}, nil
+	}
+
+	m := openPasteImport(t, sizedModel(nil))
+	want := "User:\nfirst line\nsecond line\n\nAssistant:\nanswer"
+	m.importFlow.pasteInput.SetValue(want)
+
+	// Ordinary Enter is owned by the textarea and inserts a newline.
+	entered, _ := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	m = asModel(t, entered)
+	if !strings.Contains(m.importFlow.pasteInput.Value(), "\n") {
+		t.Fatalf("textarea lost multiline input: %q", m.importFlow.pasteInput.Value())
+	}
+	if m.importFlow.step != importEnterSource {
+		t.Fatalf("plain Enter advanced from textarea: step=%v", m.importFlow.step)
+	}
+
+	reviewing, cmd := m.Update(ctrlEnter())
+	m = asModel(t, reviewing)
+	if cmd == nil || m.importFlow.busy == "" {
+		t.Fatal("Ctrl+Enter did not start asynchronous parsing")
+	}
+	parsedModel, _ := m.Update(cmd())
+	m = asModel(t, parsedModel)
+	if m.importFlow.step != importPreview || parsed != m.importFlow.pasteInput.Value() {
+		t.Fatalf("parse result/input mismatch: step=%v parsed=%q input=%q", m.importFlow.step, parsed, m.importFlow.pasteInput.Value())
+	}
+}
+
+func TestPastedTextTabFocusesVisibleReviewAction(t *testing.T) {
+	previous := parseImportText
+	t.Cleanup(func() { parseImportText = previous })
+	parseImportText = func(value string, options importer.TextOptions) (importer.Conversation, error) {
+		return importer.Conversation{
+			SourceKind: importer.SourcePastedText,
+			Messages:   []importer.Message{{Role: importer.RoleUser, Text: value}},
+		}, nil
+	}
+
+	m := openPasteImport(t, sizedModel(nil))
+	m.importFlow.pasteInput.SetValue("User:\nportable review")
+
+	focused, _ := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyTab}))
+	m = asModel(t, focused)
+	if !m.importFlow.reviewFocused || !strings.Contains(m.View().Content, "Review conversation") {
+		t.Fatalf("Tab did not focus the visible Review action:\n%s", m.View().Content)
+	}
+
+	reviewing, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	m = asModel(t, reviewing)
+	if cmd == nil || m.importFlow.busy == "" {
+		t.Fatal("Enter on the focused Review action did not start parsing")
+	}
+	parsed, _ := m.Update(cmd())
+	m = asModel(t, parsed)
+	if m.importFlow.step != importPreview {
+		t.Fatalf("review action ended at step %v, want preview", m.importFlow.step)
+	}
+}
+
+func TestAmbiguousPasteRequiresLabelsOrVisibleOneNoteToggle(t *testing.T) {
+	previous := parseImportText
+	t.Cleanup(func() { parseImportText = previous })
+
+	parseImportText = func(value string, options importer.TextOptions) (importer.Conversation, error) {
+		if options.AsOneContextNote {
+			return importer.Conversation{SourceKind: importer.SourcePastedText, Messages: []importer.Message{{Role: importer.RoleUser, Text: value}}}, nil
+		}
+		conversation := importer.Conversation{SourceKind: importer.SourcePastedText, Messages: []importer.Message{{Role: importer.RoleUnassigned, Text: value}}}
+		return conversation, &importer.AmbiguityError{UnassignedBlocks: 1, Conversation: conversation}
+	}
+
+	m := openPasteImport(t, sizedModel(nil))
+	m.importFlow.pasteInput.SetValue("unlabelled historical context")
+	started, cmd := m.Update(ctrlEnter())
+	m = asModel(t, started)
+	failed, _ := m.Update(cmd())
+	m = asModel(t, failed)
+	view := m.importView()
+	for _, want := range []string{"User:/Assistant:", "one context note", "ctrl+r"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("ambiguity help missing %q:\n%s", want, view)
+		}
+	}
+
+	toggled, _ := m.Update(tea.KeyPressMsg(tea.Key{Code: 'r', Mod: tea.ModCtrl}))
+	m = asModel(t, toggled)
+	if !m.importFlow.asNote {
+		t.Fatal("one-context-note toggle did not turn on")
+	}
+	started, cmd = m.Update(ctrlEnter())
+	m = asModel(t, started)
+	previewed, _ := m.Update(cmd())
+	m = asModel(t, previewed)
+	if m.importFlow.step != importPreview || len(m.importFlow.conversation.Messages) != 1 {
+		t.Fatalf("as-note parse did not reach one-message preview: %#v", m.importFlow.conversation)
+	}
+}
+
+func TestExistingDestinationShowsCapabilityReasonAndBlocksUnsupportedAppend(t *testing.T) {
+	previous := planSessionImport
+	t.Cleanup(func() { planSessionImport = previous })
+	plans := 0
+	planSessionImport = func(request session.ImportRequest) (session.ImportPlan, error) {
+		plans++
+		return session.ImportPlan{}, errors.New("must not be called")
+	}
+
+	row := session.Row{Provider: session.ProviderClaude, ID: "exact-claude-id", CWD: t.TempDir()}
+	m := sizedModel([]session.Row{row})
+	m.importFlow = previewWizard()
+
+	destination, _ := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	m = asModel(t, destination)
+	chooseExisting, _ := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyDown}))
+	m = asModel(t, chooseExisting)
+	existing, _ := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	m = asModel(t, existing)
+	blocked, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	m = asModel(t, blocked)
+	if cmd != nil || plans != 0 {
+		t.Fatalf("unsupported append reached PlanImport: cmd=%v plans=%d", cmd, plans)
+	}
+	view := m.importView()
+	if !strings.Contains(view, "exact-claude-id") || !strings.Contains(view, "no verified native append-context API") {
+		t.Fatalf("existing target/capability reason missing:\n%s", view)
+	}
+}
+
+func TestImportApplySuccessAndErrorStates(t *testing.T) {
+	previous := applySessionImport
+	t.Cleanup(func() { applySessionImport = previous })
+
+	t.Run("success keeps receipt id and never resumes", func(t *testing.T) {
+		applySessionImport = func(_ context.Context, _ session.ImportPlan) (session.ImportReceipt, error) {
+			return session.ImportReceipt{
+				Mode:         session.ImportAppendContext,
+				Provider:     session.ProviderCodex,
+				Row:          session.Row{Provider: session.ProviderCodex, ID: "preserved-id", CWD: "C:\\project"},
+				MessageCount: 2,
+			}, nil
+		}
+		m := sizedModel(nil)
+		m.importFlow = reviewWizard(session.ImportAppendContext)
+		started, cmd := m.Update(ctrlEnter())
+		m = asModel(t, started)
+		if cmd == nil || m.selected != nil {
+			t.Fatal("apply did not start asynchronously or selected a resume action")
+		}
+		completed, _ := m.Update(cmd())
+		m = asModel(t, completed)
+		if m.importFlow.step != importSuccess || m.selected != nil {
+			t.Fatalf("success state=%v selection=%#v", m.importFlow.step, m.selected)
+		}
+		view := m.importView()
+		if !strings.Contains(view, "preserved-id") || !strings.Contains(view, "may not appear as chat bubbles") {
+			t.Fatalf("append receipt is unclear:\n%s", view)
+		}
+	})
+
+	t.Run("apply error stays visible", func(t *testing.T) {
+		applySessionImport = func(_ context.Context, _ session.ImportPlan) (session.ImportReceipt, error) {
+			return session.ImportReceipt{}, errors.New("target changed; review again")
+		}
+		m := sizedModel(nil)
+		m.importFlow = reviewWizard(session.ImportCreate)
+		started, cmd := m.Update(ctrlEnter())
+		m = asModel(t, started)
+		failed, _ := m.Update(cmd())
+		m = asModel(t, failed)
+		if m.importFlow.step != importDestination || !strings.Contains(m.importView(), "Import failed") {
+			t.Fatalf("apply error state is not visible: step=%v\n%s", m.importFlow.step, m.importView())
+		}
+	})
+}
+
+func TestBusyImportCannotBeDismissedBeforeItsResult(t *testing.T) {
+	m := sizedModel(nil)
+	m.importFlow = reviewWizard(session.ImportCreate)
+	started, cmd := m.Update(ctrlEnter())
+	m = asModel(t, started)
+	if cmd == nil || m.importFlow.busy == "" {
+		t.Fatal("apply did not enter a busy state")
+	}
+
+	afterEscape, _ := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEsc}))
+	m = asModel(t, afterEscape)
+	if m.importFlow == nil || m.importFlow.busy == "" {
+		t.Fatal("Escape hid an import while its native write was still running")
+	}
+}
+
+func ctrlEnter() tea.KeyPressMsg {
+	return tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter, Mod: tea.ModCtrl})
+}
+
+func openPasteImport(t *testing.T, m model) model {
+	t.Helper()
+	opened, _ := m.Update(tea.KeyPressMsg(tea.Key{Code: 'i'}))
+	m = asModel(t, opened)
+	chosen, _ := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyDown}))
+	m = asModel(t, chosen)
+	input, _ := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	return asModel(t, input)
+}
+
+func previewWizard() *importWizard {
+	return &importWizard{
+		step: importPreview,
+		conversation: importer.Conversation{
+			SourceKind: importer.SourcePastedText,
+			Messages:   []importer.Message{{Role: importer.RoleUser, Text: "question"}},
+		},
+	}
+}
+
+func reviewWizard(mode session.ImportMode) *importWizard {
+	wizard := previewWizard()
+	wizard.step = importReview
+	wizard.plan = session.ImportPlan{
+		PlanVersion:  1,
+		OperationID:  "test-plan",
+		Mode:         mode,
+		Provider:     session.ProviderCodex,
+		CWD:          "C:\\project",
+		Target:       session.Row{Provider: session.ProviderCodex, ID: "preserved-id", CWD: "C:\\project"},
+		MessageCount: 2,
+	}
+	return wizard
+}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -11,6 +11,7 @@ type keyMap struct {
 	Down      key.Binding
 	Page      key.Binding
 	Search    key.Binding
+	Import    key.Binding
 	Resume    key.Binding
 	Collapse  key.Binding
 	Compound  key.Binding
@@ -33,6 +34,7 @@ func defaultKeys() keyMap {
 		Down:     key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("↓/j", "down")),
 		Page:     key.NewBinding(key.WithKeys("pgup", "pgdown"), key.WithHelp("pgup/pgdn", "page")),
 		Search:   key.NewBinding(key.WithKeys("/"), key.WithHelp("/", "search")),
+		Import:   key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "import")),
 		Resume:   key.NewBinding(key.WithKeys("enter", "ctrl+m"), key.WithHelp("enter", "resume")),
 		Collapse: key.NewBinding(key.WithKeys("space", " "), key.WithHelp("space", "collapse")),
 		Compound: key.NewBinding(key.WithKeys("C"), key.WithHelp("C", "compound")),
@@ -67,13 +69,13 @@ func providerFilterKeys() []string {
 // ShortHelp is the one-line hint shown under the header. Entries are ordered
 // by importance because narrow terminals truncate the tail.
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Resume, k.Search, k.Providers, k.Preview, k.Target, k.Scope, k.Convert, k.Branch, k.Delete, k.Rescan, k.Yolo, k.Compound, k.Help, k.Quit}
+	return []key.Binding{k.Resume, k.Import, k.Search, k.Providers, k.Preview, k.Target, k.Scope, k.Convert, k.Branch, k.Delete, k.Rescan, k.Yolo, k.Compound, k.Help, k.Quit}
 }
 
 // FullHelp is the multi-column layout shown when the user presses "?".
 func (k keyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
-		{k.Up, k.Down, k.Page, k.Search},
+		{k.Up, k.Down, k.Page, k.Search, k.Import},
 		{k.Resume, k.Collapse, k.Compound, k.Convert, k.Branch},
 		{k.Delete, k.Preview, k.Target, k.Scope, k.Yolo},
 		{k.Providers, k.Rescan, k.Help, k.Quit},

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -227,6 +227,7 @@ type model struct {
 	compoundChoosing bool
 	compoundRow      *session.Row
 	compoundNotice   string
+	importFlow       *importWizard
 	isDark           bool
 	width            int
 	height           int
@@ -348,8 +349,17 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.applyDelete(msg)
 	case conversionPreviewMsg:
 		return m.applyConversionPreview(msg)
+	case importParsedMsg:
+		return m.applyImportParsed(msg)
+	case importPlannedMsg:
+		return m.applyImportPlanned(msg)
+	case importAppliedMsg:
+		return m.applyImportApplied(msg)
 	case tea.KeyPressMsg:
 		return m.handleKey(msg)
+	}
+	if m.importFlow != nil {
+		return m.updateImportInput(msg)
 	}
 
 	var cmd tea.Cmd
@@ -365,6 +375,10 @@ func (m model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 		return m, nil
+	}
+
+	if m.importFlow != nil {
+		return m.updateImport(msg)
 	}
 
 	// The compound chooser is a modal: pick the agent by digit, or cancel.
@@ -435,6 +449,8 @@ func (m model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 
 	switch {
+	case key.Matches(msg, m.keys.Import):
+		return m.openImport()
 	case key.Matches(msg, m.keys.Resume):
 		if header, ok := m.list.SelectedItem().(headerItem); ok {
 			return m.toggleGroup(header.path)
@@ -801,6 +817,8 @@ func (m model) View() tea.View {
 	switch {
 	case m.loading:
 		content = m.loadingView()
+	case m.importFlow != nil:
+		content = m.importView()
 	case m.compoundChoosing:
 		content = m.compoundView()
 	case len(m.allRows) == 0:
@@ -1120,7 +1138,7 @@ func (m model) emptyView() string {
 	}
 	lines = append(lines,
 		"",
-		th.hint.Render("Start a conversation with a supported agent, then press r to rescan."),
+		th.hint.Render("Press i to Import conversation, or r to rescan local sessions."),
 		th.hint.Render("Press q to quit."),
 	)
 	body := strings.Join(lines, "\n")

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1138,7 +1138,7 @@ func (m model) emptyView() string {
 	}
 	lines = append(lines,
 		"",
-		th.hint.Render("Press i to Import conversation, or r to rescan local sessions."),
+		th.hint.Render("Press i to Import conversation; press r to rescan local sessions."),
 		th.hint.Render("Press q to quit."),
 	)
 	body := strings.Join(lines, "\n")

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -370,6 +370,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	// Keep the terminal's unconditional interrupt available inside every
+	// import step, including while a native write is in progress.
+	if msg.String() == "ctrl+c" {
+		return m, tea.Quit
+	}
+
 	if m.loading {
 		if key.Matches(msg, m.keys.Quit) {
 			return m, tea.Quit

--- a/scripts/verify-handoff.py
+++ b/scripts/verify-handoff.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 """Exercise a built binary with disposable conversations, never the user's stores.
 
-Optional --codex checks the native local thread reader, without a model call.
+Optional --codex checks the native local thread reader. The harness does not
+instrument the real app-server method exchange, so model-call absence remains
+unverified by this real-binary check.
 File conversion, native loading, and model continuation are separate evidence.
 """
 
@@ -269,8 +271,10 @@ def verify(binary, report, codex=None):
                     "Imported context was not persisted in the native transcript")
             report["native_context_import"] = {
                 "status": "passed", "version": command(codex, ["--version"], env, workspace).strip(),
-                "method": "thread/inject_items", "same_session_id": True,
-                "original_prefix_preserved": True, "model_call": False,
+                "same_session_id": True,
+                "original_prefix_preserved": True,
+                "app_server_exchange_observation": "not_instrumented",
+                "model_call_observation": "not_instrumented",
                 "native_history_visible": False,
             }
             passed("actual Codex app-server context import preserves ID and native prefix")
@@ -282,7 +286,7 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--binary", required=True, type=Path)
     parser.add_argument("--report", type=Path)
-    parser.add_argument("--codex", type=Path, help="Optional real Codex executable; local reader only, no model calls")
+    parser.add_argument("--codex", type=Path, help="Optional real Codex executable; model-call traffic is not instrumented")
     args = parser.parse_args()
     report = {"date_utc": dt.datetime.now(dt.timezone.utc).isoformat(), "platform": platform.platform(),
               "checks": [], "synthetic_conversion": "not_run", "native_loader": {"status": "not_run"},

--- a/scripts/verify-handoff.py
+++ b/scripts/verify-handoff.py
@@ -31,6 +31,7 @@ def isolated_env(root):
         "CLAUDE_CONFIG_DIR": "claude", "GEMINI_CLI_HOME": "gemini",
         "OPENCODE_DATA_HOME": "opencode", "JCODE_HOME": "jcode",
         "PI_CODING_AGENT_DIR": "pi", "PI_CODING_AGENT_SESSION_DIR": "pi/sessions",
+        "SHOWAGENT_STATE_DIR": "showagent-state",
         "SHOWAGENT_LEARNINGS_DIR": "learnings", "PATH": "empty-bin",
         "TEMP": "tmp", "TMP": "tmp", "TMPDIR": "tmp",
     }
@@ -159,7 +160,8 @@ def verify(binary, report, codex=None):
         report["binary_version"] = invoke("--version").strip()
         report["binary_sha256"] = hashlib.sha256(binary.read_bytes()).hexdigest()
         help_text = invoke("--help")
-        require("transcript" in help_text and "--dry-run" in help_text, "Help lacks advertised commands")
+        require("transcript" in help_text and "import" in help_text and "--dry-run" in help_text,
+                "Help lacks advertised commands")
         require(json.loads(invoke("list", "--json")) == [], "External sessions leaked into isolated environment")
         passed("empty discovery and advertised help")
         session_id, source, marker = seed(root, workspace)
@@ -199,10 +201,79 @@ def verify(binary, report, codex=None):
         require(json.loads(invoke("transcript", pi[0]["id"], "--json"))["turns"] == expected[-2:], "Scope trimming mismatch")
         bounded = json.loads(invoke("transcript", returned_id, "--max-turns", "2", "--json"))
         require(bounded["truncated"] and bounded["turns"] == expected[-2:], "Transcript bound mismatch")
+        import_source = root / "web-conversation.txt"
+        import_source.write_text(
+            "User:\nBring this web decision into the project.\n\n"
+            "Assistant:\nKeep Unicode: Türkçe — and code indentation.\n"
+            "```go\n  imported()\n```\n",
+            encoding="utf-8",
+        )
+        before_import = files(root)
+        preview = json.loads(invoke(
+            "import", "--file", str(import_source), "--to", "codex",
+            "--cwd", str(workspace), "--dry-run", "--json",
+        ))
+        require(preview["dry_run"] and preview["message_count"] == 2,
+                "Web conversation import preview mismatch")
+        require(files(root) == before_import, "Import dry-run changed the filesystem")
+        imported_result = json.loads(invoke(
+            "import", "--file", str(import_source), "--to", "codex",
+            "--cwd", str(workspace), "--json",
+        ))
+        imported_id = imported_result["session_id"]
+        imported = json.loads(invoke("transcript", imported_id, "--json"))
+        expected_import = [
+            {"role": "user", "text": "Bring this web decision into the project."},
+            {"role": "assistant", "text": "Keep Unicode: Türkçe — and code indentation.\n```go\n  imported()\n```"},
+        ]
+        require(imported["turns"] == expected_import,
+                "Imported web conversation changed text or roles: " + repr(imported["turns"]))
+        repeated_import = json.loads(invoke(
+            "import", "--file", str(import_source), "--to", "codex",
+            "--cwd", str(workspace), "--json",
+        ))
+        require(repeated_import.get("no_op") is True and repeated_import["session_id"] == imported_id,
+                "Repeated create import was not a verified no-op")
+        passed("text import preview, native Codex creation and idempotent retry")
         require(hashlib.sha256(source.read_bytes()).hexdigest() == original_hash, "Original fixture was changed")
         passed("scoped copy, bounded transcript and original preservation")
         report["synthetic_conversion"] = "passed"
         if codex:
+            env["PATH"] = os.pathsep.join((str(codex.parent), env["PATH"]))
+            append_source = root / "append-context.txt"
+            append_marker = "imported-context-" + uuid.uuid4().hex
+            append_source.write_text(
+                "User:\nUse this imported context marker: " + append_marker + "\n\n"
+                "Assistant:\nContext received without starting a model turn.\n",
+                encoding="utf-8",
+            )
+            native_files = [path for path in (root / "codex" / "sessions").rglob("*.jsonl")
+                            if returned_id in path.name]
+            require(len(native_files) == 1, "Could not identify the exact Codex append target")
+            original = native_files[0].read_bytes()
+            append_result = json.loads(invoke(
+                "import", "--file", str(append_source), "--into", "codex:" + returned_id, "--json",
+            ))
+            require(append_result["session_id"] == returned_id and append_result["operation"] == "append-context",
+                    "Context import changed the target session identity")
+            updated = native_files[0].read_bytes()
+            require(len(updated) > len(original) and updated.startswith(original),
+                    "Context import did not preserve the original native prefix")
+            repeated_append = json.loads(invoke(
+                "import", "--file", str(append_source), "--into", "codex:" + returned_id, "--json",
+            ))
+            require(repeated_append.get("no_op") is True and native_files[0].read_bytes() == updated,
+                    "Repeated context import wrote duplicate native records")
+            appended_transcript = json.loads(invoke("transcript", returned_id, "--max-turns", "2", "--json"))
+            require(append_marker in json.dumps(appended_transcript["turns"]),
+                    "Imported context was not persisted in the native transcript")
+            report["native_context_import"] = {
+                "status": "passed", "version": command(codex, ["--version"], env, workspace).strip(),
+                "method": "thread/inject_items", "same_session_id": True,
+                "original_prefix_preserved": True, "model_call": False,
+                "native_history_visible": False,
+            }
+            passed("actual Codex app-server context import preserves ID and native prefix")
             report["native_loader"] = {"status": "failed", "reason": "Native reader validation did not complete"}
             report["native_loader"] = native_codex_read(codex, env, workspace, returned_id, marker)
 
@@ -215,6 +286,7 @@ def main():
     args = parser.parse_args()
     report = {"date_utc": dt.datetime.now(dt.timezone.utc).isoformat(), "platform": platform.platform(),
               "checks": [], "synthetic_conversion": "not_run", "native_loader": {"status": "not_run"},
+              "native_context_import": {"status": "not_run"},
               "model_continuation": {"status": "not_run", "reason": "This harness does not call a model."}}
     try:
         verify(args.binary.resolve(strict=True), report, args.codex.resolve(strict=True) if args.codex else None)


### PR DESCRIPTION
## Summary

Web conversations can now move into the local coding workflow without a manual role-by-role rewrite. `showagent import` accepts an accessible ChatGPT or Claude share link, a transcript file, or stdin; previews the user/assistant boundary; and creates a native session for the selected agent and project folder.

An exact existing Codex session can also receive the imported messages as model context while preserving its ID and stored prefix. The implementation uses Codex app-server injection without requesting `turn/start`; the contract test records that method boundary. Other providers remain create-only until they expose an equivalent verified append contract.

The terminal picker exposes the same flow under `i`, including the empty state. Both Review and Apply work with Tab/Enter as well as Ctrl+Enter. Pasting preserves original text and tabs, normalizes Windows line endings once, and explicitly replaces the source. Large or formatting-sensitive pastes retain their full original behind a bounded read-only editor preview.

## Behavior and boundaries

| Input or target | Result |
| --- | --- |
| Public ChatGPT/Claude share | Parses the recognized provider snapshot as inert data |
| Text file or stdin | Requires explicit speaker labels, or an explicit one-context-note choice |
| Versioned JSON transcript | Preserves validated user/assistant roles |
| New session | Uses the existing native writer for the selected provider |
| `--into codex:EXACT_ID` | Adds context to that exact session through the native context-injection path |
| Unsupported existing-session target | Explains why append is unavailable and blocks the write |

Share fetching is restricted to the two documented HTTPS share-host/path shapes. Redirects and resolved addresses are revalidated, proxies and browser cookies are excluded, response sizes are bounded, and URL-bearing errors are sanitized so access tokens do not reach normal error output. Parsers accept provider-specific envelopes and fail closed when a page is ambiguous or has drifted.

Receipts contain hashes, counts, target identity, and native revisions. They omit transcript text, share URLs, and project paths. A committed receipt turns an identical retry into a verified no-op; a prepared receipt stops an uncertain retry before it can duplicate history.

Previews show completeness, omitted-content counts, and secret-redacted first/last boundaries. Attachment-only turns do not discard later valid text; hidden non-text blocks are excluded. Escaped native-record limits are checked before writing. Local creation failures remain retryable when the atomic write has not committed, and retries verify the native import prefix without mistaking user-authored instruction text for disposable scaffolding.

Append is intended for inactive Codex sessions: close other clients using the target first. Revision and prefix checks detect changes, but showagent cannot enforce a lock across unrelated Codex/Desktop processes. The final review states this limitation. Existing-session append for other providers, MCP import, attachments, full-message browsing/range selection, and automatic model continuation remain outside this delivery.

## Verification

- [x] `go test ./... -race -shuffle=on -covermode=atomic` on Linux CI
- [x] Focused importer, session import, CLI import, and TUI import tests pass
- [x] `go vet ./...`
- [x] `golangci-lint run`
- [x] Isolated handoff harness passes all 8 checks with Codex CLI `0.153.4`
- [x] Native Codex probe preserves the exact session ID and original JSONL prefix, persists imported context, returns an idempotent no-op on retry, and remains readable by Codex 0.153.4; the real RPC exchange was not instrumented for model-call observation
- [x] Live dry-run against current public share formats parsed 2 ChatGPT messages and 20 Claude messages without writing a session
- [x] Independent correctness, security, adversarial, testing, reliability, performance, API, maintainability and product checks; confirmed defects corrected, with real paste/clipboard regressions and native-create retries across every provider
- [x] Five local providers pass normal and assistant-only create/retry cases; OpenCode uses an isolated fake-CLI fixture in Linux CI
- [x] No unresolved PR review threads at the final check; this does not claim a fresh third-party review on every pushed commit
- [x] [Final CI on `4561f35`](https://github.com/aytzey/showagent/actions/runs/34275510290): 81.5% total coverage, importer 88.1%; all package floors, vulnerability scan, isolated demo checks, and five platform builds passed
- [x] Documentation updated for commands, TUI controls, privacy, receipts, and compatibility claims

The local `go test ./...` run still exposes existing Windows-specific failures around POSIX mode assertions, test PATH executables, and home-directory assumptions. The new-package and changed-path tests pass; Linux CI is the complete repository gate.

## Provider safety

- [x] Existing sessions are modified only for an exact, reviewed Codex ID
- [x] Tests and the native harness use temporary provider homes, not real local session stores
- [x] Fake-server contract evidence records `thread/inject_items` and rejects model/runtime methods; the real CLI `0.153.4` harness separately proves identity, prefix, persistence, retry, and readability
- [x] Public share-page formats are described as provider-controlled and potentially unstable

## New concepts

### Capability-safe share fetching

A public share URL is both an address and a bearer-like capability. The importer validates the scheme, host, path, redirects, and every resolved address while keeping the full URL out of diagnostics and receipts.

```mermaid
flowchart LR
  U[Reviewed share URL] --> V[Validate host and path]
  V --> D[Resolve public IPs]
  D --> F[Bounded fetch without cookies or proxy]
  F --> P[Provider-specific inert parser]
  P -->|one exact candidate| C[Conversation preview]
  P -->|ambiguous or changed| X[Fail closed]
```

This is appropriate for narrow public-import adapters. It should not become a general-purpose URL fetcher or authenticated browser scraper.

### Prepared and committed import receipts

The native write cannot be wrapped in the same transaction as showagent's local state. A prepared receipt records intent before the write; a committed receipt records the verified outcome afterward. That makes safe retries explicit across process interruption.

| Receipt state | Retry behavior |
| --- | --- |
| Missing | Prepare and perform the reviewed import |
| Prepared | Stop as outcome-uncertain; do not write again |
| Committed and verified | Return the original target as a no-op |

This pattern fits side effects whose outcome may outlive the caller. It does not replace a provider-native idempotency key when one exists.

## Post-deploy monitoring and validation

For the first seven days, maintainers should watch CI and issue reports for `conversation could not be identified`, public snapshot fetch failures, `import target changed`, and `outcome uncertain`. Healthy behavior is a stable live dry-run message count for known public fixtures, exact-ID Codex persistence, verified no-op retries, and no `turn/start` in contract tests.

If one provider changes its public share format, keep its link adapter fail-closed and direct users to paste/file import while updating fixtures and the provider-specific parser. Native text import and the other provider adapter remain available.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Import ChatGPT and Claude conversations from share links, files, pasted text, standard input, or JSON.
  - Create native sessions or append context to existing Codex sessions.
  - Use the new interactive import wizard, including clipboard paste, previews, review, and ambiguity resolution.
  - Preview imports with redacted message boundaries, completeness details, and source-loss warnings.
  - Apply imports safely with retry-aware, idempotent behavior.

- **Bug Fixes**
  - Improved validation, size limits, URL safety, privacy protections, and error handling for imports.

- **Documentation**
  - Added CLI usage, privacy guidance, provider limitations, compatibility details, and import workflow documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->